### PR TITLE
chore(ci): Remove Snyk security scanning

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -23,15 +23,7 @@ jobs:
       
     - name: Run security audit
       run: npm audit --audit-level=moderate
-      
-    - name: Run Snyk security scan
-      uses: snyk/actions/node@master
-      continue-on-error: true
-      env:
-        SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
-      with:
-        args: --severity-threshold=medium
-        
+
   dependency-review:
     name: Dependency Review
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- Remove Snyk integration from the security workflow
- The project will continue to use npm audit for vulnerability scanning

## Notes
- The `SNYK_TOKEN` secret can be removed from the repository settings as it's no longer needed