### PR TITLE
fix(test): Correct visual tests URL and improve server wait

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,7 +77,11 @@ jobs:
     - name: Start server and run accessibility tests
       run: |
         npm run serve &
-        sleep 3
+        # Wait for server to be ready (up to 30 seconds)
+        for i in {1..30}; do
+          curl -s http://localhost:8080 > /dev/null && break
+          sleep 1
+        done
         npm run test:visual
       
   bundle-analysis:

--- a/test/visual-regression.test.js
+++ b/test/visual-regression.test.js
@@ -5,7 +5,7 @@
 import { test, expect } from '@playwright/test';
 
 // Test configuration
-const TEST_URL = 'http://localhost:8080/example.html';
+const TEST_URL = 'http://localhost:8080/examples/vanilla-js.html';
 const VIEWPORT_SIZES = [
   { width: 1280, height: 720, name: 'desktop' },
   { width: 768, height: 1024, name: 'tablet' },


### PR DESCRIPTION
## Summary
Fixes for visual regression tests in CI:
- Change TEST_URL from non-existent `example.html` to `examples/vanilla-js.html`
- Replace fixed 3-second sleep with curl-based server readiness check (up to 30 seconds)

## Root Cause
The visual tests were failing because:
1. `example.html` doesn't exist - examples are in `/examples/` directory
2. Fixed sleep wasn't reliable for server startup

## Test plan
- [x] All 145 unit tests pass
- [ ] Visual tests should pass in CI with correct URL