### PR TITLE
fix(bundle): Include banner/blocker/sync renderers in published dist

### DIFF
--- a/examples/vanilla-js.html
+++ b/examples/vanilla-js.html
@@ -82,11 +82,8 @@
       </div>
     </div>
 
-    <!-- Include the scripts directly from source -->
-    <script src="../src/js/consent-manager.js"></script>
-    <script src="../src/js/banner.js"></script>
-    <script src="../src/js/cookie-blocker.js"></script>
-    <script src="../src/js/subdomain-sync.js"></script>
+    <!-- Include the built UMD bundle (exposes window.initCookieBanner, window.CookieConsent, etc.) -->
+    <script src="../dist/cookie-banner.js"></script>
     <script>
       // Wait for scripts to load then initialize
       setTimeout(() => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -7474,6 +7474,18 @@
         }
       }
     },
+    "node_modules/git-raw-commits/node_modules/conventional-commits-filter": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/conventional-commits-filter/-/conventional-commits-filter-5.0.0.tgz",
+      "integrity": "sha512-tQMagCOC59EVgNZcC5zl7XqO30Wki9i9J3acbUvkaosCT6JX3EeFwJD7Qqp4MCikRnzS18WXV3BLIQ66ytu6+Q==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/git-raw-commits/node_modules/meow": {
       "version": "13.2.0",
       "resolved": "https://registry.npmjs.org/meow/-/meow-13.2.0.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1163,10 +1163,11 @@
       }
     },
     "node_modules/@babel/plugin-transform-modules-systemjs": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.29.0.tgz",
-      "integrity": "sha512-PrujnVFbOdUpw4UHiVwKvKRLMMic8+eC0CuNlxjsyZUiBjhFdPsewdXCkveh2KqBA9/waD0W1b4hXSOBQJezpQ==",
+      "version": "7.29.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.29.4.tgz",
+      "integrity": "sha512-N7QmZ0xRZfjHOfZeQLJjwgX2zS9pdGHSVl/cjSGlo4dXMqvurfxXDMKY4RqEKzPozV78VMcd0lxyG13mlbKc4w==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@babel/helper-module-transforms": "^7.28.6",
         "@babel/helper-plugin-utils": "^7.28.6",
@@ -2349,10 +2350,11 @@
       }
     },
     "node_modules/@eslint/config-array/node_modules/brace-expansion": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
@@ -3073,16 +3075,17 @@
       }
     },
     "node_modules/@nodable/entities": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-1.1.0.tgz",
-      "integrity": "sha512-bidpxmTBP0pOsxULw6XlxzQpTgrAGLDHGBK/JuWhPDL6ZV0GZ/PmN9CA9do6e+A9lYI6qx6ikJUtJYRxup141g==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-2.1.0.tgz",
+      "integrity": "sha512-nyT7T3nbMyBI/lvr6L5TyWbFJAI9FTgVRakNoBqCD+PmID8DzFrrNdLLtHMwMszOtqZa8PAOV24ZqDnQrhQINA==",
       "dev": true,
       "funding": [
         {
           "type": "github",
           "url": "https://github.com/sponsors/nodable"
         }
-      ]
+      ],
+      "license": "MIT"
     },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
@@ -6670,10 +6673,11 @@
       }
     },
     "node_modules/eslint/node_modules/brace-expansion": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
@@ -6934,9 +6938,9 @@
       "dev": true
     },
     "node_modules/fast-uri": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
-      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
       "dev": true,
       "funding": [
         {
@@ -6947,12 +6951,13 @@
           "type": "opencollective",
           "url": "https://opencollective.com/fastify"
         }
-      ]
+      ],
+      "license": "BSD-3-Clause"
     },
     "node_modules/fast-xml-builder": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.1.5.tgz",
-      "integrity": "sha512-4TJn/8FKLeslLAH3dnohXqE3QSoxkhvaMzepOIZytwJXZO69Bfz0HBdDHzOTOon6G59Zrk6VQ2bEiv1t61rfkA==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.2.0.tgz",
+      "integrity": "sha512-00aAWieqff+ZJhsXA4g1g7M8k+7AYoMUUHF+/zFb5U6Uv/P0Vl4QZo84/IcufzYalLuEj9928bXN9PbbFzMF0Q==",
       "dev": true,
       "funding": [
         {
@@ -6960,14 +6965,16 @@
           "url": "https://github.com/sponsors/NaturalIntelligence"
         }
       ],
+      "license": "MIT",
       "dependencies": {
-        "path-expression-matcher": "^1.1.3"
+        "path-expression-matcher": "^1.5.0",
+        "xml-naming": "^0.1.0"
       }
     },
     "node_modules/fast-xml-parser": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.6.0.tgz",
-      "integrity": "sha512-5G+uaEBbOm9M4dgMOV3K/rBzfUNGqGqoUTaYJM3hBwM8t71w07gxLQZoTsjkY8FtfjabqgQHEkeIySBDYeBmJw==",
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.8.0.tgz",
+      "integrity": "sha512-6bIM7fsJxeo3uXv7OncQYsBAMPJ7V16Slahl/6M98C/i2q+vB1+4a0MtrvYwDFEUrwDSbAmeLDRXsOBwrL7yAg==",
       "dev": true,
       "funding": [
         {
@@ -6975,11 +6982,13 @@
           "url": "https://github.com/sponsors/NaturalIntelligence"
         }
       ],
+      "license": "MIT",
       "dependencies": {
-        "@nodable/entities": "^1.1.0",
-        "fast-xml-builder": "^1.1.4",
+        "@nodable/entities": "^2.1.0",
+        "fast-xml-builder": "^1.2.0",
         "path-expression-matcher": "^1.5.0",
-        "strnum": "^2.2.3"
+        "strnum": "^2.3.0",
+        "xml-naming": "^0.1.0"
       },
       "bin": {
         "fxparser": "src/cli/cli.js"
@@ -7463,17 +7472,6 @@
         "conventional-commits-parser": {
           "optional": true
         }
-      }
-    },
-    "node_modules/git-raw-commits/node_modules/conventional-commits-filter": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/conventional-commits-filter/-/conventional-commits-filter-5.0.0.tgz",
-      "integrity": "sha512-tQMagCOC59EVgNZcC5zl7XqO30Wki9i9J3acbUvkaosCT6JX3EeFwJD7Qqp4MCikRnzS18WXV3BLIQ66ytu6+Q==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">=18"
       }
     },
     "node_modules/git-raw-commits/node_modules/meow": {
@@ -10128,10 +10126,11 @@
       }
     },
     "node_modules/markdownlint-cli/node_modules/brace-expansion": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
@@ -11390,6 +11389,7 @@
           "url": "https://github.com/sponsors/NaturalIntelligence"
         }
       ],
+      "license": "MIT",
       "engines": {
         "node": ">=14.0.0"
       }
@@ -12637,10 +12637,11 @@
       }
     },
     "node_modules/rimraf/node_modules/brace-expansion": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
@@ -13422,16 +13423,17 @@
       }
     },
     "node_modules/strnum": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.2.3.tgz",
-      "integrity": "sha512-oKx6RUCuHfT3oyVjtnrmn19H1SiCqgJSg+54XqURKp5aCMbrXrhLjRN9TjuwMjiYstZ0MzDrHqkGZ5dFTKd+zg==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.3.0.tgz",
+      "integrity": "sha512-ums3KNd42PGyx5xaoVTO1mjU1bH3NpY4vsrVlnv9PNGqQj8wd7rJ6nEypLrJ7z5vxK5RP0yMLo6J/Gsm62DI5Q==",
       "dev": true,
       "funding": [
         {
           "type": "github",
           "url": "https://github.com/sponsors/NaturalIntelligence"
         }
-      ]
+      ],
+      "license": "MIT"
     },
     "node_modules/stylelint": {
       "version": "17.8.0",
@@ -14721,10 +14723,11 @@
       }
     },
     "node_modules/ws": {
-      "version": "8.20.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
-      "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
+      "version": "8.20.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.1.tgz",
+      "integrity": "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
       },
@@ -14748,6 +14751,22 @@
       "dev": true,
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/xml-naming": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/xml-naming/-/xml-naming-0.1.0.tgz",
+      "integrity": "sha512-k8KO9hrMyNk6tUWqUfkTEZbezRRpONVOzUTnc97VnCvyj6Tf9lyUR9EDAIeiVLv56jsMcoXEwjW8Kv5yPY52lw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.0.0"
       }
     },
     "node_modules/xmlchars": {

--- a/src/js/banner.js
+++ b/src/js/banner.js
@@ -5,7 +5,12 @@
  * @version 1.0.0
  */
 
-(function () {
+// Wrapped in an IIFE so the existing internal helpers, state, and indentation
+// stay untouched while still surfacing the public API as ES-module exports.
+// Without the explicit export+import chain in index.js, Rollup's tree-shaker
+// previously dropped this entire module from the published bundle and left
+// `window.initCookieBanner` undefined. See AFixt/cookie-banner#... for context.
+const _bannerAPI = (function () {
   'use strict';
 
   // Default configuration
@@ -680,15 +685,29 @@
     document.dispatchEvent(event);
   }
 
-  // Export public API
-  window.initCookieBanner = initCookieBanner;
+  // Return the public API so it survives Rollup tree-shaking via the module
+  // binding below. Globals are set outside the IIFE for the same reason.
+  return { initCookieBanner, getConsent, setConsent, hasConsent };
+})();
+
+// Expose the renderer on `window` for script-tag and ESM consumers alike.
+if (typeof window !== 'undefined') {
+  window.initCookieBanner = _bannerAPI.initCookieBanner;
 
   // Only create CookieConsent if it doesn't already exist
   if (!window.CookieConsent) {
     window.CookieConsent = {
-      getConsent,
-      setConsent,
-      hasConsent,
+      getConsent: _bannerAPI.getConsent,
+      setConsent: _bannerAPI.setConsent,
+      hasConsent: _bannerAPI.hasConsent,
     };
   }
-})();
+}
+
+// ES-module exports. The fact that these are imported from `src/js/index.js`
+// is what guarantees Rollup keeps `_bannerAPI` (and therefore the entire IIFE)
+// in the published bundle.
+export const initCookieBanner = _bannerAPI.initCookieBanner;
+export const getConsent = _bannerAPI.getConsent;
+export const setConsent = _bannerAPI.setConsent;
+export const hasConsent = _bannerAPI.hasConsent;

--- a/src/js/cookie-blocker.js
+++ b/src/js/cookie-blocker.js
@@ -5,7 +5,11 @@
  * @version 1.0.0
  */
 
-(function () {
+// See banner.js for why the IIFE result is captured into a module-level
+// binding and re-exported: Rollup tree-shakes side-effect-only IIFE imports
+// out of the published bundle. The exported binding below is what guarantees
+// this module survives bundling.
+const _blockerAPI = (function () {
   'use strict';
 
   // Common tracking script patterns to block
@@ -653,37 +657,47 @@
     document.removeEventListener('cookieConsentChanged', handleConsentChange);
   }
 
-  // Export functions to global scope
-  if (typeof window !== 'undefined') {
-    /**
-     * Cookie blocker API
-     * @namespace window.CookieBlocker
-     * @property {Function} init - Initialize the cookie blocker
-     * @property {Function} disable - Disable script and cookie blocking
-     * @property {Function} enable - Enable script and cookie blocking
-     * @property {Function} getBlocked - Get list of blocked scripts
-     */
-    window.CookieBlocker = Object.freeze({
-      init: initCookieBlocker,
-      getBlocked: getBlockedScripts,
-      // Internal method for testing - not part of public API contract
-      _reset: resetCookieBlocker,
-    });
-
-
-    /**
-     * Initialize the cookie blocker (backward compatibility)
-     * @function
-     * @memberof window
-     * @deprecated Use window.CookieBlocker.init() instead
-     */
-    window.initCookieBlocker = initCookieBlocker;
-
-    // Auto-initialize when script loads
-    if (document.readyState === 'loading') {
-      document.addEventListener('DOMContentLoaded', initCookieBlocker);
-    } else {
-      initCookieBlocker();
-    }
-  }
+  // Return the public API; globals + auto-init are wired up outside the IIFE
+  // so the bindings stay live for the bundler.
+  return {
+    initCookieBlocker,
+    getBlockedScripts,
+    resetCookieBlocker,
+  };
 })();
+
+// Expose the cookie blocker API on `window` for script-tag consumers.
+if (typeof window !== 'undefined') {
+  /**
+   * Cookie blocker API
+   * @namespace window.CookieBlocker
+   */
+  window.CookieBlocker = Object.freeze({
+    init: _blockerAPI.initCookieBlocker,
+    getBlocked: _blockerAPI.getBlockedScripts,
+    // Internal method for testing - not part of public API contract
+    _reset: _blockerAPI.resetCookieBlocker,
+  });
+
+  /**
+   * @deprecated Use window.CookieBlocker.init() instead
+   */
+  window.initCookieBlocker = _blockerAPI.initCookieBlocker;
+
+  // Auto-initialize when script loads. Best-effort: never let init failures
+  // propagate out of the module evaluation (tests mock Object.defineProperty
+  // to throw at load time, and the consent UI should still load).
+  try {
+    if (document.readyState === 'loading') {
+      document.addEventListener('DOMContentLoaded', _blockerAPI.initCookieBlocker);
+    } else {
+      _blockerAPI.initCookieBlocker();
+    }
+  } catch (err) {
+    console.warn('[Cookie Banner] Cookie blocker auto-init failed:', err && err.message);
+  }
+}
+
+// ES-module exports — referenced from `src/js/index.js` to defeat tree-shaking.
+export const initCookieBlocker = _blockerAPI.initCookieBlocker;
+export const getBlockedScripts = _blockerAPI.getBlockedScripts;

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -7,9 +7,15 @@
 
 // Import required modules
 import ConsentManager from './consent-manager.js';
-import './banner.js';
-import './cookie-blocker.js';
-import './subdomain-sync.js';
+// Importing a binding from each side-effect module (instead of a bare
+// `import './banner.js'`) is what keeps the renderer in the bundle. Rollup's
+// tree-shaker drops IIFE-only modules that have no referenced exports, so
+// without this the previously published `dist/` contained only the wrapper
+// below and `window.initCookieBanner` was never defined. Reproduces with
+// rollup@4 and the default treeshake options.
+import { initCookieBanner } from './banner.js';
+import { initCookieBlocker } from './cookie-blocker.js';
+import { initSubdomainSync } from './subdomain-sync.js';
 
 /**
  * @namespace CookieBanner
@@ -38,8 +44,10 @@ import './subdomain-sync.js';
  * @property {boolean} [categories.marketing=false] - Marketing cookies default
  */
 
-// Export the ConsentManager class for advanced usage
-export { ConsentManager };
+// Re-export the side-module entry points so the bindings are referenced
+// (which forces Rollup to keep cookie-blocker.js and subdomain-sync.js in the
+// published bundle) and so advanced consumers can call them directly.
+export { ConsentManager, initCookieBanner, initCookieBlocker, initSubdomainSync };
 
 // For UMD builds, expose the API on the global object after the modules are loaded
 if (typeof window !== 'undefined') {
@@ -65,16 +73,7 @@ if (typeof window !== 'undefined') {
      *   onConsentChange: (consent) => console.log('Consent changed:', consent)
      * });
      */
-    init: options => {
-      // Use function wrapper to ensure initCookieBanner is resolved at call time
-      // This fixes timing issues in ESM environments where banner.js IIFE may not
-      // have executed by the time this module is evaluated
-      if (typeof window.initCookieBanner === 'function') {
-        return window.initCookieBanner(options);
-      }
-      console.error('CookieBanner: initCookieBanner not available. Ensure banner.js is loaded.');
-      return Promise.reject(new Error('initCookieBanner not available'));
-    },
+    init: options => initCookieBanner(options),
 
     /**
      * Get current consent status

--- a/src/js/subdomain-sync.js
+++ b/src/js/subdomain-sync.js
@@ -5,7 +5,9 @@
  * @version 1.0.0
  */
 
-(function () {
+// See banner.js for why the IIFE result is captured into a module-level
+// binding and re-exported.
+const _subdomainSyncAPI = (function () {
   'use strict';
 
   /**
@@ -514,23 +516,26 @@
     };
   }
 
-  // Export API
-  if (typeof window !== 'undefined') {
-    window.CookieConsentSync = {
-      init: initSubdomainSync,
-      stop: stopSubdomainSync,
-      getStatus: getSyncStatus,
-      generateSyncHTML: generateSyncEndpointHTML,
-    };
-  }
-
-  // CommonJS export for Node.js environments
-  if (typeof module !== 'undefined' && module.exports) {
-    module.exports = {
-      initSubdomainSync,
-      stopSubdomainSync,
-      getSyncStatus,
-      generateSyncEndpointHTML,
-    };
-  }
+  return {
+    initSubdomainSync,
+    stopSubdomainSync,
+    getSyncStatus,
+    generateSyncEndpointHTML,
+  };
 })();
+
+// Expose API on `window` for script-tag consumers.
+if (typeof window !== 'undefined') {
+  window.CookieConsentSync = {
+    init: _subdomainSyncAPI.initSubdomainSync,
+    stop: _subdomainSyncAPI.stopSubdomainSync,
+    getStatus: _subdomainSyncAPI.getSyncStatus,
+    generateSyncHTML: _subdomainSyncAPI.generateSyncEndpointHTML,
+  };
+}
+
+// ES-module exports — referenced from `src/js/index.js` to defeat tree-shaking.
+export const initSubdomainSync = _subdomainSyncAPI.initSubdomainSync;
+export const stopSubdomainSync = _subdomainSyncAPI.stopSubdomainSync;
+export const getSyncStatus = _subdomainSyncAPI.getSyncStatus;
+export const generateSyncEndpointHTML = _subdomainSyncAPI.generateSyncEndpointHTML;

--- a/test/error-handling.test.js
+++ b/test/error-handling.test.js
@@ -348,22 +348,28 @@ describe('Error Handling', () => {
     });
 
     test('should handle cookie property override errors', () => {
-      // Mock defineProperty to throw
+      // Re-require the module BEFORE mocking defineProperty. Babel's CJS
+      // transform of the new `export const ...` statements emits its own
+      // `Object.defineProperty(exports, "__esModule", ...)` at the top of
+      // the file, so a mock that throws on any defineProperty call would
+      // crash module evaluation before the test body runs.
+      jest.resetModules();
+      require('../src/js/cookie-blocker.js');
+
       const originalDefineProperty = Object.defineProperty;
       Object.defineProperty = jest.fn().mockImplementation(() => {
         throw new Error('Property definition failed');
       });
 
-      // Reinitialize blocker
-      jest.resetModules();
-      require('../src/js/cookie-blocker.js');
-
-      // Should not throw
-      expect(() => {
-        window.initCookieBlocker();
-      }).not.toThrow();
-
-      Object.defineProperty = originalDefineProperty;
+      try {
+        // Calling init now hits the mocked defineProperty inside
+        // overrideCookieProperty; the try/catch there should swallow it.
+        expect(() => {
+          window.initCookieBlocker();
+        }).not.toThrow();
+      } finally {
+        Object.defineProperty = originalDefineProperty;
+      }
     });
 
     test('should handle consent manager unavailability', () => {


### PR DESCRIPTION
## Summary

Rollup's tree-shaker was dropping `banner.js`, `cookie-blocker.js`, and `subdomain-sync.js` from the published `dist/cookie-banner.{esm,js,min.js}` bundles. The shipped `init()` proxy then called `window.initCookieBanner`, which was never defined, and every consumer saw:

```
CookieBanner: initCookieBanner not available. Ensure banner.js is loaded.
```

This is the upstream cause of [meetabl-ui#500](https://github.com/AFixt/meetabl-ui/issues/500) and is reproducible across `1.0.3` and `1.1.1`.

## Root cause

The three side-effect modules are IIFEs that only write to `window`. Bare `import './banner.js'` imports in `src/js/index.js` had no referenced bindings, so Rollup considered them tree-shakable and silently dropped the IIFEs from the published bundle. Setting `treeshake.moduleSideEffects: true` (the default), `'no-external'`, or a per-id callback all produced the same result — the IIFE bodies were eliminated regardless.

## Fix

- Capture each IIFE result into a module-level binding (`const _bannerAPI = (function () { ... return {...}; })();`).
- Move the `window.*` assignments outside the IIFE so they're in the module's top-level statement list.
- Re-export the entry points from `src/js/index.js`. The referenced bindings defeat the tree-shake.
- Wrap the cookie-blocker auto-init in `try/catch` so a `defineProperty` failure during module evaluation no longer kills the whole consent flow.

## Verified

Bundle size grows ESM 252 → 2086 lines; UMD 263 → similar.

```text
$ node smoke.js
typeof window.CookieBanner: object
typeof window.CookieBanner.init: function
typeof window.initCookieBanner: function
typeof window.CookieConsent: object
typeof window.CookieBlocker: object
typeof window.CookieConsentSync: object
```

Also smoke-tested end-to-end against meetabl-ui by replacing the package's `dist/` files in its container `node_modules` and reloading: 0 console errors, 0 warnings, and the banner UI now renders with "Accept All / Reject All / Customize" buttons. `window.CookieConsent.getConsent()` round-trips.

## Test plan

- [x] `npm test` — 138/138 pass (`error-handling.test.js` cookie-blocker tests updated to re-require before mocking `Object.defineProperty`; Babel's CJS transform of `export const` now injects an `__esModule` defineProperty at the top of the file, so the prior mock-first order crashed inside `require()` before the test body ran).
- [x] `npm run lint` — clean.
- [x] `npm run build` — produces working ESM + UMD + min UMD bundles.
- [x] Browser smoke test through Vite dev server against meetabl-ui.