### PR TITLE
fix(bundle): Rename bundles to consent.* to avoid ad-blocker filtering

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ npm install @afixt/accessible-cookie-banner
 
 ```html
 <link rel="stylesheet" href="path/to/dist/banner.css" />
-<script src="path/to/dist/cookie-banner.min.js"></script>
+<script src="path/to/dist/consent.min.js"></script>
 ```
 
 ## Usage
@@ -161,9 +161,10 @@ To add a new language, create a new JSON file in the `locales` directory with th
 ```text
 accessible-cookie-banner/
 ├── dist/                    # Distribution files
-│   ├── cookie-banner.js     # UMD build
-│   ├── cookie-banner.min.js # Minified UMD build
-│   ├── cookie-banner.esm.js # ES module
+│   ├── consent.js           # UMD build
+│   ├── consent.min.js       # Minified UMD build
+│   ├── consent.esm.js       # ES module
+│   ├── cookie-banner.*.js   # Deprecated aliases (see Ad blockers below)
 │   ├── banner.css           # Styles
 │   ├── locales/             # Localization files
 │   ├── types/               # TypeScript declarations
@@ -222,7 +223,34 @@ This will build the project and start a local HTTP server at `http://localhost:8
 - RTL support: `http://localhost:8080/dist/examples/rtl-support.html`
 - Custom categories: `http://localhost:8080/dist/examples/custom-categories.html`
 
-**Note:** If you encounter issues with ad blockers blocking `cookie-banner.min.js`, either disable your ad blocker for localhost or use the unminified version by changing script references from `cookie-banner.min.js` to `cookie-banner.js`.
+### Ad blockers
+
+Ad blockers subscribe to anti-annoyance filter lists (EasyList Cookie List,
+Fanboy's Annoyance List) whose entire purpose is suppressing cookie consent
+UI. Those lists match the substring `cookie-banner` in a request path, so a
+script with that name can be cancelled before it ever executes — and the
+blocked resource is the consent mechanism itself, so no banner renders and no
+consent is recorded.
+
+For this reason the bundles are named `consent.js`, `consent.min.js` and
+`consent.esm.js`. **Use those names.**
+
+The old `cookie-banner.*.js` filenames are still published as copies so
+existing integrations keep working, but they are deprecated, they are subject
+to blocking, and they will be removed in the next major release.
+
+Two further recommendations:
+
+- **Self-host the bundle rather than loading it from a CDN.** The package name
+  contains `cookie-banner` too, so a CDN URL such as
+  `unpkg.com/@afixt/accessible-cookie-banner/dist/consent.min.js` still carries
+  the blocked substring in its path even with the renamed file.
+- **Avoid putting `cookie-banner`, `cookie-consent`, or `cookie-notice` in the
+  path you serve the script from**, for the same reason.
+
+If the script fails to load during local development, check your blocker's
+logger before assuming a build problem — a blocked request usually surfaces as
+`ERR_BLOCKED_BY_CLIENT` or `ERR_FAILED` rather than a 404.
 
 See the [examples directory](src/examples/) for more detailed examples and implementation guides.
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -37,7 +37,7 @@ Or, you can view the compiled examples in the `dist/examples/` directory after r
 <link rel="stylesheet" href="path/to/banner.css" />
 
 <!-- Include the JavaScript -->
-<script src="path/to/cookie-banner.min.js"></script>
+<script src="path/to/consent.min.js"></script>
 
 <script>
   // Initialize the cookie banner

--- a/examples/vanilla-js.html
+++ b/examples/vanilla-js.html
@@ -43,7 +43,7 @@
 &lt;link rel="stylesheet" href="path/to/banner.css"&gt;
 
 &lt;!-- Include the JavaScript --&gt;
-&lt;script src="path/to/cookie-banner.js"&gt;&lt;/script&gt;
+&lt;script src="path/to/consent.js"&gt;&lt;/script&gt;
 
 &lt;script&gt;
   // Initialize the cookie banner
@@ -83,7 +83,7 @@
     </div>
 
     <!-- Include the built UMD bundle (exposes window.initCookieBanner, window.CookieConsent, etc.) -->
-    <script src="../dist/cookie-banner.js"></script>
+    <script src="../dist/consent.js"></script>
     <script>
       // Wait for scripts to load then initialize
       setTimeout(() => {

--- a/package.json
+++ b/package.json
@@ -3,8 +3,8 @@
   "version": "1.1.1",
   "description": "A customizable, WCAG-conformant cookie consent banner with GDPR, CCPA compliance",
   "type": "module",
-  "main": "dist/cookie-banner.js",
-  "module": "dist/cookie-banner.esm.js",
+  "main": "dist/consent.js",
+  "module": "dist/consent.esm.js",
   "types": "dist/types/index.d.ts",
   "files": [
     "dist",
@@ -33,7 +33,7 @@
     "docs:build": "npm run docs:clean && npm run docs && npm run docs:md",
     "size": "size-limit",
     "size:analyze": "npm run build && size-limit && npm run analyze",
-    "analyze": "npx webpack-bundle-analyzer dist/cookie-banner.js --mode static --report bundle-report.html --no-open",
+    "analyze": "npx webpack-bundle-analyzer dist/consent.js --mode static --report bundle-report.html --no-open",
     "prepublishOnly": "npm run test:all && npm run build",
     "install:playwright": "playwright install",
     "prepare": "husky",
@@ -137,12 +137,12 @@
   },
   "size-limit": [
     {
-      "path": "./dist/cookie-banner.min.js",
+      "path": "./dist/consent.min.js",
       "limit": "15kb",
       "gzip": true
     },
     {
-      "path": "./dist/cookie-banner.js",
+      "path": "./dist/consent.js",
       "limit": "35kb"
     },
     {

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -13,18 +13,36 @@ import analyzer from 'rollup-plugin-analyzer';
 const production = !process.env.ROLLUP_WATCH;
 const outputDir = 'dist';
 
+/**
+ * Bundles are emitted as `consent.*` rather than `cookie-banner.*`.
+ *
+ * Ad-blocker annoyance lists (EasyList Cookie List, Fanboy's Annoyance List)
+ * match the substring `cookie-banner` in request paths, so a script by that
+ * name can be cancelled before it executes — taking the consent UI with it.
+ * See https://github.com/AFixt/cookie-banner/issues/66.
+ *
+ * The legacy `cookie-banner.*` names are still emitted as copies so existing
+ * `<script src>` references keep working. They are deprecated and will be
+ * removed in the next major version.
+ */
+const LEGACY_ALIASES = [
+  ['consent.js', 'cookie-banner.js'],
+  ['consent.min.js', 'cookie-banner.min.js'],
+  ['consent.esm.js', 'cookie-banner.esm.js'],
+];
+
 export default {
   input: 'src/js/index.js',
   output: [
     {
-      file: `${outputDir}/cookie-banner.js`,
+      file: `${outputDir}/consent.js`,
       format: 'umd',
       name: 'CookieBanner',
       exports: 'named',
       sourcemap: !production,
     },
     {
-      file: `${outputDir}/cookie-banner.min.js`,
+      file: `${outputDir}/consent.min.js`,
       format: 'umd',
       name: 'CookieBanner',
       exports: 'named',
@@ -32,7 +50,7 @@ export default {
       sourcemap: !production,
     },
     {
-      file: `${outputDir}/cookie-banner.esm.js`,
+      file: `${outputDir}/consent.esm.js`,
       format: 'es',
       exports: 'named',
       sourcemap: !production,
@@ -59,6 +77,16 @@ export default {
         { src: 'README.md', dest: outputDir },
         { src: 'LICENSE', dest: outputDir },
       ],
+    }),
+    // Deprecated `cookie-banner.*` aliases. Runs at writeBundle so the renamed
+    // bundles exist on disk by the time they are copied.
+    copy({
+      hook: 'writeBundle',
+      targets: LEGACY_ALIASES.map(([from, to]) => ({
+        src: `${outputDir}/${from}`,
+        dest: outputDir,
+        rename: to,
+      })),
     }),
     // Add bundle analyzer only in development or when explicitly requested
     process.env.ANALYZE &&

--- a/src/html/vanilla-example.html
+++ b/src/html/vanilla-example.html
@@ -52,7 +52,7 @@
 
       <h3>Implementation</h3>
       <pre><code>&lt;link rel="stylesheet" href="path/to/banner.css"&gt;
-&lt;script src="path/to/cookie-banner.min.js"&gt;&lt;/script&gt;
+&lt;script src="path/to/consent.min.js"&gt;&lt;/script&gt;
 
 &lt;script&gt;
   window.CookieBanner.init({

--- a/test/bundle-filenames.test.js
+++ b/test/bundle-filenames.test.js
@@ -1,0 +1,102 @@
+/**
+ * Guards against reintroducing an ad-blockable bundle filename.
+ *
+ * Anti-annoyance filter lists (EasyList Cookie List, Fanboy's Annoyance List)
+ * match these substrings in request paths in order to suppress cookie consent
+ * UI. A bundle named `cookie-banner.min.js` can therefore be cancelled by the
+ * browser before it executes, so no banner renders and no consent is recorded —
+ * a silent failure invisible to CI and to any clean browser profile.
+ *
+ * See https://github.com/AFixt/cookie-banner/issues/66.
+ *
+ * Note: the npm package name (`@afixt/accessible-cookie-banner`) deliberately
+ * still contains `cookie-banner`. That name only reaches the network for CDN
+ * consumers, which this project does not document, and it carries real
+ * discoverability value. These assertions are about asset paths only — do not
+ * "fix" the package name to satisfy them.
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const ROOT = path.join(__dirname, '..');
+const pkg = JSON.parse(fs.readFileSync(path.join(ROOT, 'package.json'), 'utf8'));
+const rollupConfig = fs.readFileSync(path.join(ROOT, 'rollup.config.js'), 'utf8');
+
+/** Substrings matched by anti-annoyance filter lists. */
+const BLOCKED_TOKENS = [
+  'cookie-banner',
+  'cookiebanner',
+  'cookie_banner',
+  'cookie-consent',
+  'cookie-notice',
+];
+
+/**
+ * Asserts that a path contains none of the blocked substrings.
+ *
+ * @param {string} assetPath - Path to check.
+ */
+function expectNotBlockable(assetPath) {
+  BLOCKED_TOKENS.forEach(token => {
+    expect(assetPath.toLowerCase()).not.toContain(token);
+  });
+}
+
+describe('published bundle filenames', () => {
+  it('exposes a main entry point that ad blockers will not match', () => {
+    expectNotBlockable(pkg.main);
+  });
+
+  it('exposes a module entry point that ad blockers will not match', () => {
+    expectNotBlockable(pkg.module);
+  });
+
+  it('points size-limit at the non-blockable bundles', () => {
+    expect(pkg['size-limit'].length).toBeGreaterThan(0);
+    pkg['size-limit'].forEach(entry => expectNotBlockable(entry.path));
+  });
+
+  it('builds the primary bundles under neutral names', () => {
+    ['consent.js', 'consent.min.js', 'consent.esm.js'].forEach(name => {
+      expect(rollupConfig).toContain(`${name}\``);
+    });
+  });
+});
+
+describe('deprecated filename aliases', () => {
+  it('still emits the legacy names so existing integrations keep working', () => {
+    ['cookie-banner.js', 'cookie-banner.min.js', 'cookie-banner.esm.js'].forEach(name => {
+      expect(rollupConfig).toContain(`'${name}'`);
+    });
+  });
+
+  it('copies the aliases after the bundles are written to disk', () => {
+    expect(rollupConfig).toMatch(/hook:\s*'writeBundle'/);
+  });
+});
+
+// Only meaningful after `npm run build`; dist/ is gitignored and absent on a
+// clean clone, so these are skipped rather than failing for the wrong reason.
+const distDir = path.join(ROOT, 'dist');
+const hasBuild = fs.existsSync(path.join(distDir, 'consent.js'));
+
+(hasBuild ? describe : describe.skip)('built output', () => {
+  it.each([
+    ['consent.js', 'cookie-banner.js'],
+    ['consent.min.js', 'cookie-banner.min.js'],
+    ['consent.esm.js', 'cookie-banner.esm.js'],
+  ])('%s and its %s alias are byte-identical', (current, legacy) => {
+    const a = fs.readFileSync(path.join(distDir, current));
+    const b = fs.readFileSync(path.join(distDir, legacy));
+    expect(a.equals(b)).toBe(true);
+  });
+
+  it('resolves the declared main entry point', () => {
+    expect(fs.existsSync(path.join(ROOT, pkg.main))).toBe(true);
+  });
+
+  it('resolves the declared module entry point', () => {
+    expect(fs.existsSync(path.join(ROOT, pkg.module))).toBe(true);
+  });
+});


### PR DESCRIPTION
Closes #66.

## What

Renames the distributed bundles from `cookie-banner.*` to `consent.*`.

Anti-annoyance filter lists match the substring `cookie-banner` in request paths specifically to suppress cookie consent UI. Every bundle this package shipped carried that substring, so for users running a blocker the script can be cancelled before it executes. The blocked resource *is* the consent mechanism, so the failure is silent: no banner renders, no consent is recorded, and the site operator gets no signal.

This was verified against the repository itself, whose URL path contains the same substring — `/issues` failed with `ERR_FAILED` and the repo home page showed "Cannot retrieve latest commit at this time" while the GitHub API returned everything normally.

## Changes

- Bundles emit as `consent.js`, `consent.min.js`, `consent.esm.js`.
- `main`, `module`, the three `size-limit` budgets, and the `analyze` script all point at the new names.
- **Legacy `cookie-banner.*.js` names are still emitted as byte-identical copies** via a `writeBundle`-hooked copy step, so existing `<script src>` tags and `require()` calls keep working. Deprecated; should go in the next major.
- Example and doc references updated.

## Non-breaking, per the scope decision on #66

This is additive — every previously published path still resolves to identical bytes. It ships as a **minor**, not a major. That follows the analysis in [this comment on #66](https://github.com/AFixt/cookie-banner/issues/66#issuecomment-5047709982): the package name is deliberately left alone, since it only reaches the network for CDN consumers (a path this project does not document) and it carries real npm-search value.

## The README note was wrong

The existing note advised that if ad blockers block `cookie-banner.min.js`, you should switch to `cookie-banner.js`. That never worked — the filters match the shared `cookie-banner` substring, not `.min`. It has been replaced with an explanation of the actual cause, the new names, and a recommendation to self-host (a CDN URL reintroduces the substring via the package name).

## Tests

`test/bundle-filenames.test.js` (11 tests): no published asset path contains a known filter token; the aliases are still emitted and are byte-identical to their replacements; the declared entry points resolve. The built-output assertions skip when `dist/` is absent rather than failing on a clean clone.

## Verification

- `npm run build` — succeeds, emits all six files
- `npm test` — 149 passed, 9 suites (was 138 / 8)
- `npm run size` — passes against the renamed paths (7.13 kB gzipped vs 15 kB budget)
- `npm run lint`, `lint:md`, `lint:css`, Prettier — pass
- UMD wrapper and the `CookieBanner` global verified intact

## Deliberately not included

**`dist/banner.css` is not renamed.** I flagged `banner` as a possible filter token in #66 but have not verified it against real filter lists, and renaming it would touch 19 references on a hunch. `cookie-banner` was directly observed being blocked; `banner.css` was not. That sub-item stays open on #66.

## Pre-existing bug found nearby (not fixed here)

`examples/vanilla-js.html` loads the bundle via `../dist/consent.js`. That resolves correctly when served from the repo root, but the file is also copied to `dist/examples/`, where `../dist/...` resolves to `dist/dist/...` and 404s. The README points readers at the broken location (`http://localhost:8080/dist/examples/vanilla-js.html`).

This predates the rename — I only changed the filename on that line. Fixing it means deciding which copy is canonical, since one relative path cannot serve both locations, so it is left for a separate change.
