### PR TITLE
fix(examples): Load bundle assets from paths that resolve in dist/examples

### DIFF
--- a/examples/complete-example.html
+++ b/examples/complete-example.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Complete Cookie Banner Example</title>
-    <link rel="stylesheet" href="../css/banner.css" />
+    <link rel="stylesheet" href="./banner.css" />
     <style>
       body {
         font-family: system-ui, sans-serif;
@@ -93,8 +93,7 @@
         <pre><code>&lt;link rel="stylesheet" href="path/to/banner.css"&gt;</code></pre>
 
         <h3>2. Include the JavaScript</h3>
-        <pre><code>&lt;script src="path/to/consent-manager.js"&gt;&lt;/script&gt;
-&lt;script src="path/to/banner.js"&gt;&lt;/script&gt;</code></pre>
+        <pre><code>&lt;script src="path/to/consent.js"&gt;&lt;/script&gt;</code></pre>
 
         <h3>3. Initialize the Banner</h3>
         <pre><code>&lt;script&gt;
@@ -115,9 +114,8 @@
       <p>This is part of the Accessible Cookie Banner project.</p>
     </footer>
 
-    <!-- Include the scripts -->
-    <script src="../js/consent-manager.js"></script>
-    <script src="../js/banner.js"></script>
+    <!-- Include the built UMD bundle (exposes window.initCookieBanner, window.CookieConsent, etc.) -->
+    <script src="./consent.js"></script>
     <script>
       // Initialize the cookie banner
       window.initCookieBanner({
@@ -147,8 +145,9 @@
 
       // Reset consent button
       document.getElementById('reset-consent').addEventListener('click', () => {
-        const manager = new ConsentManager();
-        manager.clearConsent();
+        // Clear consent from localStorage and cookies
+        localStorage.removeItem('cookieConsent');
+        document.cookie = 'cookieConsent=; expires=Thu, 01 Jan 1970 00:00:00 UTC; path=/;';
         location.reload();
       });
 

--- a/examples/custom-categories.html
+++ b/examples/custom-categories.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Cookie Banner - Custom Categories Example</title>
-    <link rel="stylesheet" href="../css/banner.css" />
+    <link rel="stylesheet" href="./banner.css" />
     <style>
       body {
         font-family: system-ui, sans-serif;
@@ -99,9 +99,8 @@
       </div>
     </div>
 
-    <!-- Include the scripts -->
-    <script src="../js/consent-manager.js"></script>
-    <script src="../js/banner.js"></script>
+    <!-- Include the built UMD bundle (exposes window.initCookieBanner, window.CookieConsent, etc.) -->
+    <script src="./consent.js"></script>
     <script>
       // Initialize the cookie banner with custom categories
       window.initCookieBanner({
@@ -137,8 +136,9 @@
 
       // Reset consent button
       document.getElementById('reset-consent').addEventListener('click', () => {
-        const manager = new ConsentManager();
-        manager.clearConsent();
+        // Clear consent from localStorage and cookies
+        localStorage.removeItem('cookieConsent');
+        document.cookie = 'cookieConsent=; expires=Thu, 01 Jan 1970 00:00:00 UTC; path=/;';
         location.reload();
       });
 

--- a/examples/high-contrast.html
+++ b/examples/high-contrast.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Cookie Banner - High Contrast Example</title>
-    <link rel="stylesheet" href="../css/banner.css" />
+    <link rel="stylesheet" href="./banner.css" />
     <style>
       body {
         font-family: system-ui, sans-serif;
@@ -85,9 +85,8 @@
       </div>
     </div>
 
-    <!-- Include the scripts -->
-    <script src="../js/consent-manager.js"></script>
-    <script src="../js/banner.js"></script>
+    <!-- Include the built UMD bundle (exposes window.initCookieBanner, window.CookieConsent, etc.) -->
+    <script src="./consent.js"></script>
     <script>
       // Initialize the cookie banner with high-contrast theme
       window.initCookieBanner({
@@ -116,8 +115,9 @@
 
       // Reset consent button
       document.getElementById('reset-consent').addEventListener('click', () => {
-        const manager = new ConsentManager();
-        manager.clearConsent();
+        // Clear consent from localStorage and cookies
+        localStorage.removeItem('cookieConsent');
+        document.cookie = 'cookieConsent=; expires=Thu, 01 Jan 1970 00:00:00 UTC; path=/;';
         location.reload();
       });
 

--- a/examples/rtl-support.html
+++ b/examples/rtl-support.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Cookie Banner - RTL Support Example</title>
-    <link rel="stylesheet" href="../css/banner.css" />
+    <link rel="stylesheet" href="./banner.css" />
     <style>
       body {
         font-family: system-ui, sans-serif;
@@ -87,9 +87,8 @@
       locales.
     </p>
 
-    <!-- Include the scripts -->
-    <script src="../js/consent-manager.js"></script>
-    <script src="../js/banner.js"></script>
+    <!-- Include the built UMD bundle (exposes window.initCookieBanner, window.CookieConsent, etc.) -->
+    <script src="./consent.js"></script>
     <script>
       // Initialize the cookie banner
       window.initCookieBanner({
@@ -118,8 +117,9 @@
 
       // Reset consent button
       document.getElementById('reset-consent').addEventListener('click', () => {
-        const manager = new ConsentManager();
-        manager.clearConsent();
+        // Clear consent from localStorage and cookies
+        localStorage.removeItem('cookieConsent');
+        document.cookie = 'cookieConsent=; expires=Thu, 01 Jan 1970 00:00:00 UTC; path=/;';
         location.reload();
       });
 

--- a/examples/vanilla-js.html
+++ b/examples/vanilla-js.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Cookie Banner - Vanilla JS Example</title>
-    <link rel="stylesheet" href="../dist/banner.css" />
+    <link rel="stylesheet" href="./banner.css" />
     <style>
       body {
         font-family: system-ui, sans-serif;

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -69,6 +69,9 @@ export default {
     copy({
       targets: [
         { src: 'src/css/banner.css', dest: outputDir },
+        // The examples link `./banner.css`, so the stylesheet has to sit next
+        // to them for the same reason consent.js does. See issue #72.
+        { src: 'src/css/banner.css', dest: `${outputDir}/examples` },
         { src: 'src/locales/*', dest: `${outputDir}/locales` },
         { src: 'src/html/banner.html', dest: `${outputDir}/examples` },
         { src: 'src/html/preferences-modal.html', dest: `${outputDir}/examples` },

--- a/test/example-script-paths.test.js
+++ b/test/example-script-paths.test.js
@@ -1,46 +1,108 @@
 /**
- * Guards the script path in the vanilla JS example.
+ * Guards the asset paths in the example pages.
  *
  * `examples/*` is copied into `dist/examples/` at build time and the README
- * points readers at that copy, so the page must load the bundle with a path
- * that resolves from there. The old `../dist/consent.js` reference resolved
- * to `dist/dist/consent.js` from the copy, a 404, so the banner never
- * initialised. See https://github.com/AFixt/cookie-banner/issues/72.
+ * points readers at that copy, so every page must load its scripts and
+ * stylesheet with paths that resolve from there. Old references like
+ * `../dist/consent.js`, `../js/consent-manager.js`, `../js/banner.js` and
+ * `../css/banner.css` all 404ed from the copy (some from the source tree
+ * too), so the banner never initialised or rendered unstyled. The build
+ * copies consent.js and banner.css next to the pages so `./consent.js` and
+ * `./banner.css` resolve. See
+ * https://github.com/AFixt/cookie-banner/issues/72 and
+ * https://github.com/AFixt/cookie-banner/issues/86.
+ *
+ * banner.html and preferences-modal.html are also copied into dist/examples/
+ * from src/html/, where their relative paths do resolve; they are markup
+ * references rather than runnable examples, so they are not covered here.
  */
 
 const fs = require('fs');
 const path = require('path');
 
 const ROOT = path.join(__dirname, '..');
-const examplePage = fs.readFileSync(path.join(ROOT, 'examples', 'vanilla-js.html'), 'utf8');
-const rollupConfig = fs.readFileSync(path.join(ROOT, 'rollup.config.js'), 'utf8');
+const EXAMPLES_DIR = path.join(ROOT, 'examples');
+const examplePages = fs.readdirSync(EXAMPLES_DIR).filter(f => f.endsWith('.html'));
 
-describe('vanilla JS example script path', () => {
-  it('loads the bundle from a path that survives the copy into dist/examples', () => {
-    expect(examplePage).toContain('<script src="./consent.js"></script>');
-    expect(examplePage).not.toContain('../dist/consent.js');
+// Real tags only, tolerating extra attributes (defer, type) — escaped
+// `&lt;script src="path/to/..."&gt;` snippets inside the pages'
+// documentation blocks are intentionally not matched.
+const scriptSrcs = html => [...html.matchAll(/<script[^>]*\ssrc="([^"]+)"/g)].map(m => m[1]);
+const stylesheetHrefs = html =>
+  [...html.matchAll(/<link rel="stylesheet" href="([^"]+)"/g)].map(m => m[1]);
+
+describe('example page asset paths', () => {
+  it('finds the example pages', () => {
+    expect(examplePages).toContain('vanilla-js.html');
+    expect(examplePages.length).toBeGreaterThanOrEqual(6);
   });
 
-  it('copies the bundle next to the examples so ./consent.js resolves', () => {
-    // Tolerate reformatting: only require a copy target whose src is the
-    // consent.js bundle and whose dest is the examples directory.
+  examplePages.forEach(page => {
+    describe(page, () => {
+      const html = fs.readFileSync(path.join(EXAMPLES_DIR, page), 'utf8');
+
+      it('loads assets from paths that survive the copy into dist/examples', () => {
+        [...scriptSrcs(html), ...stylesheetHrefs(html)].forEach(src => {
+          expect(src).toMatch(/^\.\//);
+        });
+      });
+
+      it('does not reference files that are never published', () => {
+        expect(scriptSrcs(html)).not.toContain('../js/consent-manager.js');
+        expect(scriptSrcs(html)).not.toContain('../js/banner.js');
+        expect(scriptSrcs(html)).not.toContain('../dist/consent.js');
+        expect(stylesheetHrefs(html)).not.toContain('../css/banner.css');
+      });
+
+      it('does not use globals the UMD bundle never defines', () => {
+        // consent.js only sets window.CookieBanner, window.initCookieBanner,
+        // window.CookieConsent and window.CookieBlocker; a bare
+        // `new ConsentManager()` throws a ReferenceError.
+        expect(html).not.toMatch(/new ConsentManager\(/);
+      });
+    });
+  });
+});
+
+describe('rollup copies the assets next to the examples', () => {
+  const rollupConfig = fs.readFileSync(path.join(ROOT, 'rollup.config.js'), 'utf8');
+
+  // Tolerate reformatting: only require copy targets whose src is the asset
+  // and whose dest is the examples directory.
+  it('copies the bundle so ./consent.js resolves', () => {
     expect(rollupConfig).toMatch(
       /src:\s*[`'"][^`'"]*consent\.js[`'"],\s*dest:\s*[`'"][^`'"]*examples[`'"]/
+    );
+  });
+
+  it('copies the stylesheet so ./banner.css resolves', () => {
+    expect(rollupConfig).toMatch(
+      /src:\s*[`'"][^`'"]*banner\.css[`'"],\s*dest:\s*[`'"][^`'"]*examples[`'"]/
     );
   });
 });
 
 // Only meaningful after `npm run build`; dist/ is gitignored and absent on a
 // clean clone, so this is skipped rather than failing for the wrong reason.
-const builtPage = path.join(ROOT, 'dist', 'examples', 'vanilla-js.html');
+const BUILT_DIR = path.join(ROOT, 'dist', 'examples');
 
-(fs.existsSync(builtPage) ? describe : describe.skip)('built example page', () => {
-  it('resolves every script it references', () => {
-    const html = fs.readFileSync(builtPage, 'utf8');
-    const srcs = [...html.matchAll(/<script[^>]*\ssrc="([^"]+)"/g)].map(m => m[1]);
-    expect(srcs.length).toBeGreaterThan(0);
-    srcs.forEach(src => {
-      expect(fs.existsSync(path.join(path.dirname(builtPage), src))).toBe(true);
+(fs.existsSync(BUILT_DIR) ? describe : describe.skip)('built example pages', () => {
+  examplePages.forEach(page => {
+    it(`${page} resolves every script and stylesheet it references`, () => {
+      const builtPage = path.join(BUILT_DIR, page);
+      expect(fs.existsSync(builtPage)).toBe(true);
+
+      const html = fs.readFileSync(builtPage, 'utf8');
+      [...scriptSrcs(html), ...stylesheetHrefs(html)].forEach(src => {
+        expect(fs.existsSync(path.join(BUILT_DIR, src))).toBe(true);
+      });
     });
+  });
+
+  it('references at least one script across the example pages', () => {
+    const all = examplePages.flatMap(page =>
+      scriptSrcs(fs.readFileSync(path.join(BUILT_DIR, page), 'utf8'))
+    );
+    expect(all.length).toBeGreaterThan(0);
   });
 });

--- a/test/visual-regression.test.js
+++ b/test/visual-regression.test.js
@@ -5,7 +5,9 @@
 import { test, expect } from '@playwright/test';
 
 // Test configuration
-const TEST_URL = 'http://localhost:8080/examples/vanilla-js.html';
+// The built copy is the page users are pointed at (see README) and the only
+// place ./consent.js and ./banner.css resolve, so it needs `npm run build`.
+const TEST_URL = 'http://localhost:8080/dist/examples/vanilla-js.html';
 const VIEWPORT_SIZES = [
   { width: 1280, height: 720, name: 'desktop' },
   { width: 768, height: 1024, name: 'tablet' },


### PR DESCRIPTION
## Summary

Fixes #86.

`high-contrast.html`, `complete-example.html`, `custom-categories.html` and `rtl-support.html` loaded scripts via `../js/consent-manager.js` and `../js/banner.js`. No `js/` directory exists at the repo root or in `dist/`, so both requests 404 whether the pages are served from `/examples/` or from the `dist/examples/` copy the README documents — the banner never initialised on any of these pages. Their `../css/banner.css` stylesheet link also resolved nowhere, and the reset buttons called `new ConsentManager()`, a global the UMD bundle never defines.

This applies the approach from #84 (which fixed `vanilla-js.html` only) to every example page:

- Each page loads `./consent.js` (the UMD bundle) and `./banner.css`.
- `rollup.config.js` copies `src/css/banner.css` into `dist/examples/` alongside the existing `consent.js` copy, so the pages are self-contained wherever `dist/examples/` is served from.
- Reset buttons clear localStorage/cookies directly (the pattern `vanilla-js.html` already used) instead of `new ConsentManager()`, which threw a `ReferenceError`.
- `complete-example.html`'s "How To Use" snippet now shows the single published bundle instead of the two never-published per-module files.
- `test/example-script-paths.test.js` now asserts, for **every** example HTML page (source and built), that all script *and stylesheet* references are `./`-relative and resolve inside `dist/examples/`.

## Relationship to #84

This branch includes #84's commit (cherry-picked; author preserved) because the new test and rollup changes build directly on it. If #84 merges to `main` first, git will deduplicate on the next release merge; alternatively #84 can be closed in favour of this PR reaching `main` through the normal release flow.

Note: `src/html/banner.html` and `preferences-modal.html` are also copied into `dist/examples/` and still reference `../js/`/`../css/` (which do resolve from their source location `src/html/`). They're markup references rather than runnable examples, so they're deliberately excluded from the test — see the comment in the test file.

## Testing

- `npm run build && npm test` — 202 tests pass across 12 suites, including the new per-page built checks.
- Loaded `dist/examples/high-contrast.html` and `dist/examples/complete-example.html` in a browser: banner renders, `window.CookieBanner`/`window.initCookieBanner`/`window.CookieConsent` all defined, `banner.css` applied, zero console errors.
- `npm run check` (eslint, prettier, stylelint, markdownlint) passes.