### PR TITLE
chore(lint): Ignore generated artifacts in format and markdown checks

### DIFF
--- a/.markdownlintignore
+++ b/.markdownlintignore
@@ -1,0 +1,10 @@
+node_modules
+dist
+build
+coverage
+docs
+CHANGELOG.md
+playwright-report
+playwright-visual-report
+test-results
+reports

--- a/.prettierignore
+++ b/.prettierignore
@@ -8,5 +8,11 @@ package-lock.json
 yarn.lock
 pnpm-lock.yaml
 docs
+playwright-report
 playwright-visual-report
+test-results
+reports
+npm-audit-results.json
+bundle-analysis.txt
+licenses.json
 CHANGELOG.md


### PR DESCRIPTION
## Summary

The husky pre-push hook runs `npm run check` (eslint + `prettier --check .` + stylelint + markdownlint). The prettier and markdownlint steps scanned gitignored generated artifacts — `test-results/`, `playwright-visual-report/`, `npm-audit-results.json`, `bundle-analysis.txt`, `licenses.json` — and failed on them, blocking `git push` until the files were hand-deleted (hit on 2026-07-22).

## Changes

- Add the generated paths (plus `playwright-report/` and `reports/`, which are also gitignored build outputs) to `.prettierignore`
- Add a new `.markdownlintignore` covering the same generated paths; markdownlint-cli picks it up automatically, alongside the existing `--ignore` flags in the `lint:md` script

## Verification

- Seeded stray `test-results/`, `playwright-visual-report/`, `npm-audit-results.json`, `bundle-analysis.txt`, and `licenses.json` files with deliberately unformatted JSON/Markdown, then ran `npm run check` — passes cleanly
- Negative control: running prettier/markdownlint on those same seeded files with `--ignore-path=/dev/null` fails as expected, confirming the ignore files are what suppress them
- Full test suite passes (12 suites, 170 passed / 6 skipped)