### PR TITLE
refactor(core): Decompose oversized modules and enforce ESLint size limits

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -34,6 +34,19 @@ export default [
     },
   },
   {
+    // Size and complexity limits (see #62/#69). Source only — test files
+    // legitimately hold long describe blocks and fixture-heavy functions.
+    files: ['src/**/*.js'],
+    rules: {
+      'max-lines': ['error', { max: 300, skipBlankLines: true, skipComments: true }],
+      'max-lines-per-function': ['error', { max: 75, skipBlankLines: true, skipComments: true }],
+      complexity: ['error', 10],
+      'max-depth': ['error', 4],
+      'max-params': ['error', 4],
+      'max-nested-callbacks': ['error', 3],
+    },
+  },
+  {
     ignores: [
       'node_modules/**',
       'dist/**',

--- a/src/js/banner-dom.js
+++ b/src/js/banner-dom.js
@@ -1,0 +1,214 @@
+/**
+ * @fileoverview DOM construction for the cookie banner and preferences modal.
+ * Builders receive configuration and locale strings and return detached
+ * elements; the caller owns insertion into the document. Extracted from
+ * banner.js (see AFixt/cookie-banner#69).
+ * @module banner-dom
+ */
+
+/** Theme name validation pattern - alphanumeric and hyphens only (C2) */
+const THEME_REGEX = /^[a-z0-9-]+$/i;
+
+/**
+ * Apply a validated theme class to an element (C2)
+ * @param {HTMLElement} element - Element to receive the theme class
+ * @param {string} theme - Theme name from configuration
+ */
+function applyTheme(element, theme) {
+  if (theme && THEME_REGEX.test(theme)) {
+    element.classList.add(`theme-${theme}`);
+  }
+}
+
+/**
+ * Create a banner action button
+ * @param {string} id - Element id
+ * @param {string} action - data-action value
+ * @param {string} label - Visible button text
+ * @returns {HTMLButtonElement}
+ */
+function buildBannerButton(id, action, label) {
+  const button = document.createElement('button');
+  button.id = id;
+  button.setAttribute('data-action', action);
+  button.textContent = label;
+  return button;
+}
+
+/**
+ * Create the cookie banner element (detached)
+ * @param {Object} config - Banner configuration
+ * @param {Object} strings - Locale strings
+ * @returns {HTMLDivElement} The banner element
+ */
+export function createBannerElement(config, strings) {
+  const banner = document.createElement('div');
+  banner.id = 'cookie-banner';
+  banner.setAttribute('role', 'region');
+  banner.setAttribute('aria-label', 'Cookie Consent');
+  banner.setAttribute('aria-live', 'polite');
+
+  const description = document.createElement('p');
+  description.id = 'cookie-description';
+  description.textContent = strings.description;
+
+  const buttons = document.createElement('div');
+  buttons.className = 'cookie-buttons';
+
+  const acceptAllBtn = buildBannerButton('accept-all', 'accept-all', strings.acceptAll);
+  const rejectAllBtn = buildBannerButton('reject-all', 'reject-all', strings.rejectAll);
+  const customizeBtn = buildBannerButton('customize-preferences', 'customize', strings.customize);
+  if (config.showModal) {
+    customizeBtn.setAttribute('aria-haspopup', 'dialog');
+    customizeBtn.setAttribute('aria-controls', 'cookie-modal');
+  }
+
+  buttons.appendChild(acceptAllBtn);
+  buttons.appendChild(rejectAllBtn);
+  buttons.appendChild(customizeBtn);
+  banner.appendChild(description);
+  banner.appendChild(buttons);
+
+  applyTheme(banner, config.theme);
+
+  return banner;
+}
+
+/**
+ * Create one cookie-category row: a labelled checkbox with optional
+ * description paragraph.
+ * @param {Object} options - Category options
+ * @param {string} options.name - Checkbox name attribute
+ * @param {boolean} options.checked - Initial checked state
+ * @param {boolean} options.disabled - Whether the checkbox is locked
+ * @param {string} options.label - Visible label text
+ * @param {string} [options.description] - Optional description text
+ * @returns {HTMLDivElement}
+ */
+function buildCategoryRow({ name, checked, disabled, label, description }) {
+  const container = document.createElement('div');
+  container.className = 'cookie-category';
+
+  const labelElement = document.createElement('label');
+  const checkbox = document.createElement('input');
+  checkbox.type = 'checkbox';
+  checkbox.name = name;
+  checkbox.checked = checked;
+  if (disabled) {
+    checkbox.disabled = true;
+  }
+  labelElement.appendChild(checkbox);
+  labelElement.appendChild(document.createTextNode(' ' + label));
+
+  container.appendChild(labelElement);
+
+  if (description) {
+    const descriptionElement = document.createElement('p');
+    descriptionElement.className = 'cookie-description';
+    descriptionElement.textContent = description;
+    container.appendChild(descriptionElement);
+  }
+
+  return container;
+}
+
+/**
+ * Create the fieldset grouping all cookie-category checkboxes
+ * @param {Object} config - Banner configuration
+ * @param {Object} strings - Locale strings
+ * @returns {HTMLFieldSetElement}
+ */
+function buildCategoryFieldset(config, strings) {
+  const fieldset = document.createElement('fieldset');
+  const legend = document.createElement('legend');
+  legend.textContent = 'Cookie Categories';
+  fieldset.appendChild(legend);
+
+  fieldset.appendChild(
+    buildCategoryRow({
+      name: 'functional',
+      checked: true,
+      disabled: true,
+      label: strings.modal.functional,
+      description: strings.modal.functionalDescription,
+    })
+  );
+  fieldset.appendChild(
+    buildCategoryRow({
+      name: 'analytics',
+      checked: config.categories.analytics,
+      disabled: false,
+      label: strings.modal.analytics,
+      description: strings.modal.analyticsDescription,
+    })
+  );
+  fieldset.appendChild(
+    buildCategoryRow({
+      name: 'marketing',
+      checked: config.categories.marketing,
+      disabled: false,
+      label: strings.modal.marketing,
+      description: strings.modal.marketingDescription,
+    })
+  );
+
+  return fieldset;
+}
+
+/**
+ * Create the modal action buttons (save / cancel)
+ * @param {Object} strings - Locale strings
+ * @returns {HTMLDivElement}
+ */
+function buildModalActions(strings) {
+  const actions = document.createElement('div');
+  actions.className = 'cookie-modal-actions';
+
+  const saveBtn = document.createElement('button');
+  saveBtn.type = 'submit';
+  saveBtn.setAttribute('data-action', 'save');
+  saveBtn.textContent = strings.modal.save;
+
+  const cancelBtn = document.createElement('button');
+  cancelBtn.type = 'button';
+  cancelBtn.id = 'close-modal';
+  cancelBtn.setAttribute('data-action', 'cancel');
+  cancelBtn.textContent = strings.modal.cancel;
+
+  actions.appendChild(saveBtn);
+  actions.appendChild(cancelBtn);
+
+  return actions;
+}
+
+/**
+ * Create the preferences modal element (detached, hidden)
+ * @param {Object} config - Banner configuration
+ * @param {Object} strings - Locale strings
+ * @returns {HTMLDivElement} The modal element
+ */
+export function createModalElement(config, strings) {
+  const modal = document.createElement('div');
+  modal.id = 'cookie-modal';
+  modal.setAttribute('role', 'dialog');
+  modal.setAttribute('aria-modal', 'true');
+  modal.setAttribute('aria-labelledby', 'modal-title');
+  modal.setAttribute('aria-hidden', 'true');
+  modal.setAttribute('hidden', '');
+
+  const title = document.createElement('h2');
+  title.id = 'modal-title';
+  title.textContent = strings.modal.title;
+
+  const form = document.createElement('form');
+  form.id = 'cookie-form';
+  form.appendChild(buildCategoryFieldset(config, strings));
+  form.appendChild(buildModalActions(strings));
+
+  modal.appendChild(title);
+  modal.appendChild(form);
+
+  applyTheme(modal, config.theme);
+
+  return modal;
+}

--- a/src/js/banner-focus.js
+++ b/src/js/banner-focus.js
@@ -1,0 +1,81 @@
+/**
+ * @fileoverview Focus management for the preferences modal: capturing focus
+ * on open, trapping Tab/Shift+Tab inside the dialog, and restoring focus on
+ * close (WCAG 2.2 focus management). Extracted from banner.js (see
+ * AFixt/cookie-banner#69).
+ * @module banner-focus
+ */
+
+const FOCUSABLE_SELECTOR =
+  'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])';
+
+/**
+ * Create a focus manager for a modal dialog. Each manager instance owns the
+ * focus bookkeeping that previously lived as module state in banner.js.
+ * @returns {Object} Focus manager API
+ */
+export function createFocusManager() {
+  let firstFocusableElement = null;
+  let lastFocusableElement = null;
+  let previouslyFocusedElement = null;
+
+  return {
+    /**
+     * Remember the element that triggered the modal, so focus can return to
+     * it on close.
+     * @param {Element} element - The triggering element
+     */
+    rememberTrigger(element) {
+      previouslyFocusedElement = element;
+    },
+
+    /**
+     * Capture focus inside the modal: record the previously focused element
+     * (unless a trigger was already remembered) and focus the first
+     * focusable element.
+     * @param {HTMLElement} modal - The modal element
+     */
+    captureFocus(modal) {
+      if (!previouslyFocusedElement) {
+        previouslyFocusedElement = document.activeElement;
+      }
+
+      const focusableElements = modal.querySelectorAll(FOCUSABLE_SELECTOR);
+      firstFocusableElement = focusableElements[0];
+      lastFocusableElement = focusableElements[focusableElements.length - 1];
+
+      firstFocusableElement.focus();
+    },
+
+    /**
+     * Return focus to the element that had it before the modal opened.
+     */
+    restoreFocus() {
+      if (previouslyFocusedElement) {
+        previouslyFocusedElement.focus();
+        previouslyFocusedElement = null; // Reset after use
+      }
+    },
+
+    /**
+     * Keydown handler that traps Tab / Shift+Tab within the modal.
+     * @param {KeyboardEvent} e - Keyboard event
+     */
+    trapFocus(e) {
+      if (e.key !== 'Tab') {
+        return;
+      }
+      if (e.shiftKey) {
+        // Going backwards from the first element wraps to the last
+        if (document.activeElement === firstFocusableElement) {
+          e.preventDefault();
+          lastFocusableElement.focus();
+        }
+      } else if (document.activeElement === lastFocusableElement) {
+        // Going forwards from the last element wraps to the first
+        e.preventDefault();
+        firstFocusableElement.focus();
+      }
+    },
+  };
+}

--- a/src/js/banner-storage.js
+++ b/src/js/banner-storage.js
@@ -1,0 +1,93 @@
+/**
+ * @fileoverview Consent storage helpers for the cookie banner — validation,
+ * secure cookie construction, and reading/writing consent from localStorage
+ * or cookies. Extracted from banner.js (see AFixt/cookie-banner#69).
+ * @module banner-storage
+ */
+
+/**
+ * Validate a consent object against expected schema (M1)
+ * @param {Object} obj - Object to validate
+ * @returns {Object|null} Validated consent or null
+ */
+export function validateConsentData(obj) {
+  if (typeof obj !== 'object' || obj === null || Array.isArray(obj)) {
+    return null;
+  }
+  return {
+    functional: obj.functional === true,
+    analytics: obj.analytics === true,
+    marketing: obj.marketing === true,
+    timestamp: typeof obj.timestamp === 'string' ? obj.timestamp : null,
+  };
+}
+
+/**
+ * Build a cookie string with proper security attributes (H1)
+ * @param {string} name - Cookie name
+ * @param {string} value - Cookie value
+ * @param {string} expires - Expiry date string
+ * @returns {string} Complete cookie string
+ */
+export function buildSecureCookie(name, value, expires) {
+  const secureFlag = window.location.protocol === 'https:' ? '; Secure' : '';
+  return `${name}=${value}; expires=${expires}; path=/; SameSite=Lax${secureFlag}`;
+}
+
+/**
+ * Read consent from the configured storage backend.
+ * @param {string} storageMethod - 'localStorage' or 'cookie'
+ * @returns {Object|null} Validated consent object or null
+ */
+export function readStoredConsent(storageMethod) {
+  try {
+    let parsed = null;
+    if (storageMethod === 'localStorage') {
+      const storedConsent = localStorage.getItem('cookieConsent');
+      parsed = storedConsent ? JSON.parse(storedConsent) : null;
+    } else {
+      // Cookie method
+      const match = document.cookie.match(/cookieConsent=([^;]+)/);
+      parsed = match ? JSON.parse(decodeURIComponent(match[1])) : null;
+    }
+    // Validate parsed consent against expected schema (M1)
+    return parsed ? validateConsentData(parsed) : null;
+  } catch (e) {
+    console.error('Error retrieving consent:', e);
+    return null;
+  }
+}
+
+/**
+ * Persist consent to the configured storage backend. Functional cookies are
+ * always forced on and a timestamp is stamped onto the stored value.
+ * @param {Object} consent - Consent object with boolean values
+ * @param {Object} options - Storage options
+ * @param {string} options.storageMethod - 'localStorage' or 'cookie'
+ * @param {number} options.expireDays - Cookie lifetime in days
+ * @returns {Object} The consent object as stored (with timestamp)
+ */
+export function writeStoredConsent(consent, { storageMethod, expireDays }) {
+  const consentData = {
+    ...consent,
+    functional: true,
+    timestamp: new Date().toISOString(),
+  };
+
+  const consentString = JSON.stringify(consentData);
+
+  if (storageMethod === 'localStorage') {
+    localStorage.setItem('cookieConsent', consentString);
+  } else {
+    // Cookie method - Set expiry date
+    const expiryDate = new Date();
+    expiryDate.setDate(expiryDate.getDate() + expireDays);
+    document.cookie = buildSecureCookie(
+      'cookieConsent',
+      encodeURIComponent(consentString),
+      expiryDate.toUTCString()
+    );
+  }
+
+  return consentData;
+}

--- a/src/js/banner.js
+++ b/src/js/banner.js
@@ -5,6 +5,10 @@
  * @version 1.0.0
  */
 
+import { readStoredConsent, writeStoredConsent } from './banner-storage.js';
+import { createBannerElement, createModalElement } from './banner-dom.js';
+import { createFocusManager } from './banner-focus.js';
+
 // Wrapped in an IIFE so the existing internal helpers, state, and indentation
 // stay untouched while still surfacing the public API as ES-module exports.
 // Without the explicit export+import chain in index.js, Rollup's tree-shaker
@@ -28,9 +32,6 @@ const _bannerAPI = (function () {
     },
   };
 
-  /** Theme name validation pattern - alphanumeric and hyphens only (C2) */
-  const THEME_REGEX = /^[a-z0-9-]+$/i;
-
   /** Allowed config keys to prevent prototype pollution (H5) */
   const ALLOWED_BANNER_CONFIG_KEYS = [
     'locale',
@@ -45,45 +46,13 @@ const _bannerAPI = (function () {
   /** Locale format pattern (M4) */
   const LOCALE_REGEX = /^[a-z]{2}(-[A-Z]{2})?$/;
 
-  /**
-   * Validate a consent object against expected schema (M1)
-   * @param {Object} obj - Object to validate
-   * @returns {Object|null} Validated consent or null
-   */
-  function validateConsentData(obj) {
-    if (typeof obj !== 'object' || obj === null || Array.isArray(obj)) {
-      return null;
-    }
-    return {
-      functional: obj.functional === true,
-      analytics: obj.analytics === true,
-      marketing: obj.marketing === true,
-      timestamp: typeof obj.timestamp === 'string' ? obj.timestamp : null,
-    };
-  }
-
-  /**
-   * Build a cookie string with proper security attributes (H1)
-   * @param {string} name - Cookie name
-   * @param {string} value - Cookie value
-   * @param {string} expires - Expiry date string
-   * @returns {string} Complete cookie string
-   */
-  function buildSecureCookie(name, value, expires) {
-    const secureFlag = window.location.protocol === 'https:' ? '; Secure' : '';
-    return `${name}=${value}; expires=${expires}; path=/; SameSite=Lax${secureFlag}`;
-  }
-
   // State
   let config = {};
   let banner = null;
   let modal = null;
   let localeStrings = {};
-  let focusableElements = [];
-  let firstFocusableElement = null;
-  let lastFocusableElement = null;
-  let previouslyFocusedElement = null;
   let isModalOpen = false;
+  const focusManager = createFocusManager();
 
   /**
    * Initialize the cookie banner
@@ -115,11 +84,13 @@ const _bannerAPI = (function () {
         .then(() => {
           try {
             // Create and append banner
-            createBanner();
+            banner = createBannerElement(config, localeStrings);
+            document.body.appendChild(banner);
 
             // Create and append modal if enabled
             if (config.showModal) {
-              createModal();
+              modal = createModalElement(config, localeStrings);
+              document.body.appendChild(modal);
             }
 
             // Add event listeners
@@ -200,190 +171,6 @@ const _bannerAPI = (function () {
   }
 
   /**
-   * Create and append the cookie banner to the DOM
-   */
-  function createBanner() {
-    banner = document.createElement('div');
-    banner.id = 'cookie-banner';
-    banner.setAttribute('role', 'region');
-    banner.setAttribute('aria-label', 'Cookie Consent');
-    banner.setAttribute('aria-live', 'polite');
-
-    const description = document.createElement('p');
-    description.id = 'cookie-description';
-    description.textContent = localeStrings.description;
-
-    const buttons = document.createElement('div');
-    buttons.className = 'cookie-buttons';
-
-    const acceptAllBtn = document.createElement('button');
-    acceptAllBtn.id = 'accept-all';
-    acceptAllBtn.setAttribute('data-action', 'accept-all');
-    acceptAllBtn.textContent = localeStrings.acceptAll;
-
-    const rejectAllBtn = document.createElement('button');
-    rejectAllBtn.id = 'reject-all';
-    rejectAllBtn.setAttribute('data-action', 'reject-all');
-    rejectAllBtn.textContent = localeStrings.rejectAll;
-
-    const customizeBtn = document.createElement('button');
-    customizeBtn.id = 'customize-preferences';
-    customizeBtn.setAttribute('data-action', 'customize');
-    customizeBtn.textContent = localeStrings.customize;
-    if (config.showModal) {
-      customizeBtn.setAttribute('aria-haspopup', 'dialog');
-      customizeBtn.setAttribute('aria-controls', 'cookie-modal');
-    }
-
-    // Append elements
-    buttons.appendChild(acceptAllBtn);
-    buttons.appendChild(rejectAllBtn);
-    buttons.appendChild(customizeBtn);
-    banner.appendChild(description);
-    banner.appendChild(buttons);
-
-    // Apply theme (validated against allowlist - C2)
-    if (config.theme && THEME_REGEX.test(config.theme)) {
-      banner.classList.add(`theme-${config.theme}`);
-    }
-
-    // Add to the DOM
-    document.body.appendChild(banner);
-  }
-
-  /**
-   * Create and append the preferences modal to the DOM
-   */
-  function createModal() {
-    modal = document.createElement('div');
-    modal.id = 'cookie-modal';
-    modal.setAttribute('role', 'dialog');
-    modal.setAttribute('aria-modal', 'true');
-    modal.setAttribute('aria-labelledby', 'modal-title');
-    modal.setAttribute('aria-hidden', 'true');
-    modal.setAttribute('hidden', '');
-
-    const title = document.createElement('h2');
-    title.id = 'modal-title';
-    title.textContent = localeStrings.modal.title;
-
-    const form = document.createElement('form');
-    form.id = 'cookie-form';
-
-    // Cookie categories fieldset - groups all related checkboxes
-    const cookieFieldset = document.createElement('fieldset');
-    const cookieLegend = document.createElement('legend');
-    cookieLegend.textContent = 'Cookie Categories';
-    cookieFieldset.appendChild(cookieLegend);
-
-    // Functional cookies (always required)
-    const functionalDiv = document.createElement('div');
-    functionalDiv.className = 'cookie-category';
-
-    const functionalLabel = document.createElement('label');
-    const functionalCheckbox = document.createElement('input');
-    functionalCheckbox.type = 'checkbox';
-    functionalCheckbox.name = 'functional';
-    functionalCheckbox.checked = true;
-    functionalCheckbox.disabled = true;
-    functionalLabel.appendChild(functionalCheckbox);
-    functionalLabel.appendChild(document.createTextNode(' ' + localeStrings.modal.functional));
-
-    functionalDiv.appendChild(functionalLabel);
-
-    // Add description if available
-    if (localeStrings.modal.functionalDescription) {
-      const functionalDesc = document.createElement('p');
-      functionalDesc.className = 'cookie-description';
-      functionalDesc.textContent = localeStrings.modal.functionalDescription;
-      functionalDiv.appendChild(functionalDesc);
-    }
-
-    // Analytics cookies
-    const analyticsDiv = document.createElement('div');
-    analyticsDiv.className = 'cookie-category';
-
-    const analyticsLabel = document.createElement('label');
-    const analyticsCheckbox = document.createElement('input');
-    analyticsCheckbox.type = 'checkbox';
-    analyticsCheckbox.name = 'analytics';
-    analyticsCheckbox.checked = config.categories.analytics;
-    analyticsLabel.appendChild(analyticsCheckbox);
-    analyticsLabel.appendChild(document.createTextNode(' ' + localeStrings.modal.analytics));
-
-    analyticsDiv.appendChild(analyticsLabel);
-
-    // Add description if available
-    if (localeStrings.modal.analyticsDescription) {
-      const analyticsDesc = document.createElement('p');
-      analyticsDesc.className = 'cookie-description';
-      analyticsDesc.textContent = localeStrings.modal.analyticsDescription;
-      analyticsDiv.appendChild(analyticsDesc);
-    }
-
-    // Marketing cookies
-    const marketingDiv = document.createElement('div');
-    marketingDiv.className = 'cookie-category';
-
-    const marketingLabel = document.createElement('label');
-    const marketingCheckbox = document.createElement('input');
-    marketingCheckbox.type = 'checkbox';
-    marketingCheckbox.name = 'marketing';
-    marketingCheckbox.checked = config.categories.marketing;
-    marketingLabel.appendChild(marketingCheckbox);
-    marketingLabel.appendChild(document.createTextNode(' ' + localeStrings.modal.marketing));
-
-    marketingDiv.appendChild(marketingLabel);
-
-    // Add description if available
-    if (localeStrings.modal.marketingDescription) {
-      const marketingDesc = document.createElement('p');
-      marketingDesc.className = 'cookie-description';
-      marketingDesc.textContent = localeStrings.modal.marketingDescription;
-      marketingDiv.appendChild(marketingDesc);
-    }
-
-    // Add all categories to the fieldset
-    cookieFieldset.appendChild(functionalDiv);
-    cookieFieldset.appendChild(analyticsDiv);
-    cookieFieldset.appendChild(marketingDiv);
-
-    // Modal actions
-    const actions = document.createElement('div');
-    actions.className = 'cookie-modal-actions';
-
-    const saveBtn = document.createElement('button');
-    saveBtn.type = 'submit';
-    saveBtn.setAttribute('data-action', 'save');
-    saveBtn.textContent = localeStrings.modal.save;
-
-    const cancelBtn = document.createElement('button');
-    cancelBtn.type = 'button';
-    cancelBtn.id = 'close-modal';
-    cancelBtn.setAttribute('data-action', 'cancel');
-    cancelBtn.textContent = localeStrings.modal.cancel;
-
-    actions.appendChild(saveBtn);
-    actions.appendChild(cancelBtn);
-
-    // Append everything to the form
-    form.appendChild(cookieFieldset);
-    form.appendChild(actions);
-
-    // Append to modal
-    modal.appendChild(title);
-    modal.appendChild(form);
-
-    // Apply theme (validated against allowlist - C2)
-    if (config.theme && THEME_REGEX.test(config.theme)) {
-      modal.classList.add(`theme-${config.theme}`);
-    }
-
-    // Add to the DOM
-    document.body.appendChild(modal);
-  }
-
-  /**
    * Add keyboard event handler to button
    */
   function addKeyboardHandler(button, callback) {
@@ -396,27 +183,32 @@ const _bannerAPI = (function () {
   }
 
   /**
+   * Route a consent decision through an external CookieConsent manager when
+   * one is installed, otherwise store it directly. Shared by the accept,
+   * reject, and save-preferences paths.
+   * @param {Object} consentData - Consent object with boolean values
+   */
+  function applyConsent(consentData) {
+    if (window.CookieConsent && window.CookieConsent.setConsent !== setConsent) {
+      window.CookieConsent.setConsent(consentData);
+      // Also dispatch the event and call callbacks
+      dispatchConsentEvent(consentData);
+      if (typeof config.onConsentChange === 'function') {
+        config.onConsentChange(consentData);
+      }
+    } else {
+      setConsent(consentData);
+    }
+  }
+
+  /**
    * Add event listeners to buttons and form
    */
   function addEventListeners() {
     // Accept all button
     const acceptAllHandler = () => {
       try {
-        const consentData = {
-          functional: true,
-          analytics: true,
-          marketing: true,
-        };
-        if (window.CookieConsent && window.CookieConsent.setConsent !== setConsent) {
-          window.CookieConsent.setConsent(consentData);
-          // Also dispatch the event and call callbacks
-          dispatchConsentEvent(consentData);
-          if (typeof config.onConsentChange === 'function') {
-            config.onConsentChange(consentData);
-          }
-        } else {
-          setConsent(consentData);
-        }
+        applyConsent({ functional: true, analytics: true, marketing: true });
         hideBanner();
       } catch (error) {
         console.error('[Cookie Banner] Error setting consent:', error);
@@ -427,24 +219,10 @@ const _bannerAPI = (function () {
     acceptBtn.addEventListener('click', acceptAllHandler);
     addKeyboardHandler(acceptBtn, acceptAllHandler);
 
-    // Reject all button
+    // Reject all button (functional is always required)
     const rejectAllHandler = () => {
       try {
-        const consentData = {
-          functional: true, // Functional is always required
-          analytics: false,
-          marketing: false,
-        };
-        if (window.CookieConsent && window.CookieConsent.setConsent !== setConsent) {
-          window.CookieConsent.setConsent(consentData);
-          // Also dispatch the event and call callbacks
-          dispatchConsentEvent(consentData);
-          if (typeof config.onConsentChange === 'function') {
-            config.onConsentChange(consentData);
-          }
-        } else {
-          setConsent(consentData);
-        }
+        applyConsent({ functional: true, analytics: false, marketing: false });
         hideBanner();
       } catch (error) {
         console.error('[Cookie Banner] Error setting consent:', error);
@@ -460,7 +238,7 @@ const _bannerAPI = (function () {
     if (customizeBtn && config.showModal) {
       customizeBtn.addEventListener('click', e => {
         // Store the element that triggered the modal opening
-        previouslyFocusedElement = e.target;
+        focusManager.rememberTrigger(e.target);
         openModal();
       });
     }
@@ -475,21 +253,11 @@ const _bannerAPI = (function () {
         e.preventDefault();
         try {
           const form = e.target;
-          const consentData = {
+          applyConsent({
             functional: true, // Always required
             analytics: form.elements.analytics.checked,
             marketing: form.elements.marketing.checked,
-          };
-          if (window.CookieConsent && window.CookieConsent.setConsent !== setConsent) {
-            window.CookieConsent.setConsent(consentData);
-            // Also dispatch the event and call callbacks
-            dispatchConsentEvent(consentData);
-            if (typeof config.onConsentChange === 'function') {
-              config.onConsentChange(consentData);
-            }
-          } else {
-            setConsent(consentData);
-          }
+          });
           closeModal();
           hideBanner();
         } catch (error) {
@@ -505,7 +273,7 @@ const _bannerAPI = (function () {
       });
 
       // Trap focus in modal
-      modal.addEventListener('keydown', trapFocus);
+      modal.addEventListener('keydown', focusManager.trapFocus);
     }
   }
 
@@ -517,26 +285,13 @@ const _bannerAPI = (function () {
       return;
     }
 
-    // Store the element that had focus before opening the modal (if not already set)
-    if (!previouslyFocusedElement) {
-      previouslyFocusedElement = document.activeElement;
-    }
-
     // Show the modal
     modal.removeAttribute('hidden');
     modal.setAttribute('aria-hidden', 'false');
     isModalOpen = true;
 
-    // Find all focusable elements in the modal
-    focusableElements = modal.querySelectorAll(
-      'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])'
-    );
-
-    firstFocusableElement = focusableElements[0];
-    lastFocusableElement = focusableElements[focusableElements.length - 1];
-
-    // Focus the first element
-    firstFocusableElement.focus();
+    // Record prior focus and move focus into the dialog
+    focusManager.captureFocus(modal);
 
     // Add overlay
     const overlay = document.createElement('div');
@@ -564,33 +319,7 @@ const _bannerAPI = (function () {
     }
 
     // Return focus to the element that had focus before opening the modal
-    if (previouslyFocusedElement) {
-      previouslyFocusedElement.focus();
-      previouslyFocusedElement = null; // Reset after use
-    }
-  }
-
-  /**
-   * Trap focus within the modal
-   * @param {Event} e - Keyboard event
-   */
-  function trapFocus(e) {
-    // If Tab key is pressed
-    if (e.key === 'Tab') {
-      // If Shift + Tab (going backwards)
-      if (e.shiftKey) {
-        if (document.activeElement === firstFocusableElement) {
-          e.preventDefault();
-          lastFocusableElement.focus();
-        }
-      } else {
-        // If just Tab (going forwards)
-        if (document.activeElement === lastFocusableElement) {
-          e.preventDefault();
-          firstFocusableElement.focus();
-        }
-      }
-    }
+    focusManager.restoreFocus();
   }
 
   /**
@@ -608,22 +337,7 @@ const _bannerAPI = (function () {
    * @returns {Object|null} - Consent object or null if no consent is stored
    */
   function getConsentFromStorage() {
-    try {
-      let parsed = null;
-      if (config.storageMethod === 'localStorage') {
-        const storedConsent = localStorage.getItem('cookieConsent');
-        parsed = storedConsent ? JSON.parse(storedConsent) : null;
-      } else {
-        // Cookie method
-        const match = document.cookie.match(/cookieConsent=([^;]+)/);
-        parsed = match ? JSON.parse(decodeURIComponent(match[1])) : null;
-      }
-      // Validate parsed consent against expected schema (M1)
-      return parsed ? validateConsentData(parsed) : null;
-    } catch (e) {
-      console.error('Error retrieving consent:', e);
-      return null;
-    }
+    return readStoredConsent(config.storageMethod);
   }
 
   /**
@@ -640,27 +354,10 @@ const _bannerAPI = (function () {
    */
   function setConsent(consent) {
     try {
-      // Ensure functional cookies are always enabled
-      const consentData = {
-        ...consent,
-        functional: true,
-        timestamp: new Date().toISOString(),
-      };
-
-      const consentString = JSON.stringify(consentData);
-
-      if (config.storageMethod === 'localStorage') {
-        localStorage.setItem('cookieConsent', consentString);
-      } else {
-        // Cookie method - Set expiry date
-        const expiryDate = new Date();
-        expiryDate.setDate(expiryDate.getDate() + config.expireDays);
-        document.cookie = buildSecureCookie(
-          'cookieConsent',
-          encodeURIComponent(consentString),
-          expiryDate.toUTCString()
-        );
-      }
+      const consentData = writeStoredConsent(consent, {
+        storageMethod: config.storageMethod,
+        expireDays: config.expireDays,
+      });
 
       // Dispatch event
       dispatchConsentEvent(consentData);

--- a/src/js/cookie-blocker-cookies.js
+++ b/src/js/cookie-blocker-cookies.js
@@ -1,0 +1,142 @@
+/**
+ * @fileoverview document.cookie override for the cookie blocker: wraps the
+ * native cookie accessor so writes are vetted against the blocking rules,
+ * with a simulated fallback for environments (like jsdom) where the native
+ * descriptor is missing. Extracted from cookie-blocker.js (see
+ * AFixt/cookie-banner#69).
+ * @module cookie-blocker-cookies
+ */
+
+/**
+ * Build a descriptor that simulates real cookie behavior on top of a plain
+ * string, for environments where document.cookie is a simple value property
+ * (e.g. some test environments).
+ * @param {string} initialValue - Current document.cookie value
+ * @returns {Object} Property descriptor with get/set
+ */
+function createSimulatedCookieDescriptor(initialValue) {
+  let cookieStorage = initialValue || '';
+  return {
+    get: function () {
+      return cookieStorage;
+    },
+    set: function (value) {
+      // Simulate real cookie behavior
+      if (value) {
+        const [cookiePart] = value.split(';');
+        const [name, val] = cookiePart.split('=');
+        if (name && val) {
+          // Simple cookie storage simulation
+          const cookies = cookieStorage ? cookieStorage.split('; ') : [];
+          const updated = cookies.filter(c => !c.startsWith(name + '='));
+          updated.push(cookiePart.trim());
+          cookieStorage = updated.join('; ');
+        }
+      }
+      return value;
+    },
+    configurable: true,
+  };
+}
+
+/**
+ * Locate the original document.cookie accessor descriptor, falling back to a
+ * simulated one when the environment exposes cookie as a plain value.
+ * @returns {Object|null} A descriptor with get/set, or null when unusable
+ */
+function resolveOriginalCookieDescriptor() {
+  // Get the original cookie descriptor - try different locations
+  let originalDescriptor =
+    Object.getOwnPropertyDescriptor(Document.prototype, 'cookie') ||
+    Object.getOwnPropertyDescriptor(HTMLDocument.prototype, 'cookie');
+
+  // If no descriptor found in prototypes, check document directly
+  if (!originalDescriptor) {
+    originalDescriptor = Object.getOwnPropertyDescriptor(document, 'cookie');
+    // If document.cookie is a simple value property (e.g., in test environment)
+    if (!originalDescriptor || (!originalDescriptor.get && !originalDescriptor.set)) {
+      originalDescriptor = createSimulatedCookieDescriptor(document.cookie);
+    }
+  }
+
+  return originalDescriptor;
+}
+
+/**
+ * Override document.cookie so writes are vetted by the supplied predicate.
+ * Blocked writes are logged and dropped; failures in the blocking logic fail
+ * closed (the cookie is not set — L4).
+ * @param {Function} shouldBlockCookie - (cookieName) => boolean
+ */
+export function overrideCookieProperty(shouldBlockCookie) {
+  // Check if cookie property has already been overridden by us
+  if (document._cookieBlockerOverridden) {
+    return;
+  }
+
+  const originalDescriptor = resolveOriginalCookieDescriptor();
+
+  if (!originalDescriptor || !originalDescriptor.set) {
+    console.warn('[Cookie Banner] Could not find valid cookie descriptor');
+    return;
+  }
+
+  try {
+    // Store the original getter and setter
+    const originalGet = originalDescriptor.get || (() => '');
+    const originalSet = originalDescriptor.set;
+
+    Object.defineProperty(document, 'cookie', {
+      configurable: true,
+      enumerable: true,
+      get: function () {
+        try {
+          return originalGet.call(this);
+        } catch (error) {
+          console.error('[Cookie Banner] Error getting cookie:', error.message);
+          return '';
+        }
+      },
+      set: function (value) {
+        try {
+          const [cookieString] = value.split(';');
+          const [name] = cookieString.split('=');
+
+          if (shouldBlockCookie(name.trim())) {
+            console.log('Blocked cookie:', cookieString.trim());
+            return; // Don't actually set the cookie
+          }
+
+          originalSet.call(this, value);
+        } catch (error) {
+          // Fail closed: do not set the cookie if blocking logic errors (L4)
+          console.error('[Cookie Banner] Error in cookie blocking logic:', error.message);
+          return;
+        }
+      },
+    });
+
+    // Mark as overridden
+    document._cookieBlockerOverridden = true;
+  } catch (e) {
+    // Property may already be defined or not configurable
+    console.warn('[Cookie Banner] Could not override cookie property:', e.message);
+  }
+}
+
+/**
+ * Expire existing cookies that the blocking predicate rejects.
+ * @param {Function} shouldBlockCookie - (cookieName) => boolean
+ */
+export function blockExistingCookies(shouldBlockCookie) {
+  const cookies = document.cookie.split(';');
+
+  cookies.forEach(cookie => {
+    const [name] = cookie.trim().split('=');
+    if (shouldBlockCookie(name)) {
+      // Delete the cookie by setting it to expire immediately
+      document.cookie = `${name}=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; domain=${window.location.hostname}`;
+      document.cookie = `${name}=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/`;
+    }
+  });
+}

--- a/src/js/cookie-blocker-dom.js
+++ b/src/js/cookie-blocker-dom.js
@@ -1,0 +1,246 @@
+/**
+ * @fileoverview DOM API overrides for the cookie blocker: intercepts script
+ * creation (document.createElement), insertion (appendChild/insertBefore),
+ * and src assignment (setAttribute) so tracking scripts can be held back
+ * until consent is granted. Extracted from cookie-blocker.js (see
+ * AFixt/cookie-banner#69).
+ * @module cookie-blocker-dom
+ */
+
+import { getTrackingKeyword, getScriptCategory } from './cookie-blocker-rules.js';
+
+// Original DOM methods, captured when overrides are installed
+let originalCreateElement = null;
+let originalAppendChild = null;
+let originalInsertBefore = null;
+let originalSetAttribute = null;
+
+/**
+ * Create an element bypassing the createElement override (used to execute
+ * previously blocked scripts once consent arrives).
+ * @param {string} tagName - Tag to create
+ * @returns {Element}
+ */
+export function createElementBypassingBlock(tagName) {
+  const create = originalCreateElement || document.createElement;
+  return create.call(document, tagName);
+}
+
+/**
+ * Append a child bypassing the appendChild override.
+ * @param {Element} parent - Parent element
+ * @param {Element} child - Child to append
+ * @returns {Element}
+ */
+export function appendChildBypassingBlock(parent, child) {
+  const append = originalAppendChild || Element.prototype.appendChild;
+  return append.call(parent, child);
+}
+
+/**
+ * Classify a script node about to be inserted into the DOM. Returns the
+ * block record when the node must be held back, or null to let it through.
+ * Shared by the appendChild and insertBefore overrides.
+ * @param {Element} node - Node being inserted
+ * @param {Object} handlers - Blocking predicates from the coordinator
+ * @param {Function} handlers.shouldBlockScript - (src) => boolean
+ * @param {Function} handlers.shouldBlockInlineScript - (content) => boolean
+ * @returns {Object|null} Block record or null
+ */
+function classifyScriptInsertion(node, handlers) {
+  // A manual data-category attribute takes precedence over pattern matching
+  const dataCategory = node.getAttribute && node.getAttribute('data-category');
+  if (dataCategory) {
+    return classifyByDeclaredCategory(node, dataCategory);
+  }
+  return classifyByContent(node, handlers);
+}
+
+/**
+ * Classify a script that declares its own data-category attribute: blocked
+ * unless the consent manager grants that category.
+ * @param {Element} node - Script node
+ * @param {string} dataCategory - Declared category
+ * @returns {Object|null} Block record or null
+ */
+function classifyByDeclaredCategory(node, dataCategory) {
+  const consentManager = window.CookieConsent;
+  if (!consentManager || !consentManager.hasConsent || !consentManager.hasConsent(dataCategory)) {
+    console.log('Blocked tracking script:', node.src || 'inline script');
+    return {
+      element: node,
+      src: node.src,
+      innerHTML: node.innerHTML,
+      type: dataCategory,
+    };
+  }
+  return null;
+}
+
+/**
+ * Classify a script by its src URL or inline content against the blocking
+ * predicates.
+ * @param {Element} node - Script node
+ * @param {Object} handlers - Blocking predicates from the coordinator
+ * @returns {Object|null} Block record or null
+ */
+function classifyByContent(node, handlers) {
+  // Check both external scripts and inline scripts
+  if (node.src && handlers.shouldBlockScript(node.src)) {
+    console.log('Blocked tracking script:', node.src);
+    return {
+      element: node,
+      src: node.src,
+      type: getScriptCategory(node.src),
+    };
+  }
+
+  if (node.innerHTML && handlers.shouldBlockInlineScript(node.innerHTML)) {
+    console.log('Blocked inline tracking script containing:', getTrackingKeyword(node.innerHTML));
+    return {
+      element: node,
+      innerHTML: node.innerHTML,
+      type: 'analytics',
+    };
+  }
+
+  return null;
+}
+
+/**
+ * Override document.createElement to intercept script creation. Each created
+ * script gets a guarded `src` setter that consults the blocking predicate.
+ * @param {Object} handlers - Callbacks from the coordinator
+ * @param {Function} handlers.shouldBlockScript - (src) => boolean
+ * @param {Function} handlers.onBlocked - (record) => void
+ */
+export function overrideCreateElement(handlers) {
+  originalCreateElement = document.createElement;
+
+  document.createElement = function (tagName) {
+    const element = originalCreateElement.call(this, tagName);
+
+    if (tagName.toLowerCase() === 'script') {
+      // Store reference to check later when src is set
+      element._cookieBannerTracked = true;
+      installGuardedSrcSetter(element, handlers);
+    }
+
+    return element;
+  };
+}
+
+/**
+ * Install a src accessor on a script element that refuses blocked URLs.
+ * @param {HTMLScriptElement} element - Script element to guard
+ * @param {Object} handlers - Callbacks from the coordinator
+ */
+function installGuardedSrcSetter(element, handlers) {
+  // Store reference to the original src descriptor to properly set src on non-blocked scripts
+  const originalSrcDescriptor = Object.getOwnPropertyDescriptor(HTMLScriptElement.prototype, 'src');
+
+  let originalSrc = '';
+  Object.defineProperty(element, 'src', {
+    get: function () {
+      return originalSrc;
+    },
+    set: function (value) {
+      originalSrc = value;
+
+      if (handlers.shouldBlockScript(value)) {
+        console.log('[Cookie Banner] Blocked script:', value);
+        handlers.onBlocked({
+          element: element,
+          src: value,
+          type: 'analytics', // Could be enhanced to detect type
+        });
+        return; // Don't actually set the src
+      }
+
+      // Set the src normally using the original setter
+      if (originalSrcDescriptor && originalSrcDescriptor.set) {
+        originalSrcDescriptor.set.call(element, value);
+      }
+    },
+    configurable: true,
+  });
+}
+
+/**
+ * Override appendChild and insertBefore to intercept script insertion.
+ * @param {Object} handlers - Callbacks from the coordinator
+ * @param {Function} handlers.shouldBlockScript - (src) => boolean
+ * @param {Function} handlers.shouldBlockInlineScript - (content) => boolean
+ * @param {Function} handlers.onBlocked - (record) => void
+ */
+export function overrideAppendMethods(handlers) {
+  originalAppendChild = Element.prototype.appendChild;
+  originalInsertBefore = Element.prototype.insertBefore;
+
+  Element.prototype.appendChild = function (child) {
+    if (child && child.tagName === 'SCRIPT') {
+      const record = classifyScriptInsertion(child, handlers);
+      if (record) {
+        handlers.onBlocked(record);
+        return child; // Return the element but don't actually append it
+      }
+    }
+    return originalAppendChild.call(this, child);
+  };
+
+  Element.prototype.insertBefore = function (newNode, referenceNode) {
+    if (newNode && newNode.tagName === 'SCRIPT') {
+      const record = classifyScriptInsertion(newNode, handlers);
+      if (record) {
+        handlers.onBlocked(record);
+        return newNode; // Return the element but don't actually insert it
+      }
+    }
+    return originalInsertBefore.call(this, newNode, referenceNode);
+  };
+}
+
+/**
+ * Override setAttribute to catch dynamic src changes.
+ * @param {Object} handlers - Callbacks from the coordinator
+ * @param {Function} handlers.shouldBlockScript - (src) => boolean
+ * @param {Function} handlers.onBlocked - (record) => void
+ */
+export function overrideSetAttribute(handlers) {
+  originalSetAttribute = Element.prototype.setAttribute;
+
+  Element.prototype.setAttribute = function (name, value) {
+    if (this.tagName === 'SCRIPT' && name === 'src' && handlers.shouldBlockScript(value)) {
+      console.log('[Cookie Banner] Blocked script setAttribute:', value);
+      handlers.onBlocked({
+        element: this,
+        src: value,
+        type: 'analytics',
+      });
+      return; // Don't set the attribute
+    }
+    return originalSetAttribute.call(this, name, value);
+  };
+}
+
+/**
+ * Restore every overridden DOM method to its original implementation.
+ */
+export function restoreDomOverrides() {
+  if (originalCreateElement) {
+    document.createElement = originalCreateElement;
+    originalCreateElement = null;
+  }
+  if (originalAppendChild) {
+    Element.prototype.appendChild = originalAppendChild;
+    originalAppendChild = null;
+  }
+  if (originalInsertBefore) {
+    Element.prototype.insertBefore = originalInsertBefore;
+    originalInsertBefore = null;
+  }
+  if (originalSetAttribute) {
+    Element.prototype.setAttribute = originalSetAttribute;
+    originalSetAttribute = null;
+  }
+}

--- a/src/js/cookie-blocker-rules.js
+++ b/src/js/cookie-blocker-rules.js
@@ -1,0 +1,165 @@
+/**
+ * @fileoverview Pattern tables and pure classification rules for the cookie
+ * blocker: which cookies, script URLs, and inline snippets count as tracking,
+ * and whether the current consent state allows them. Extracted from
+ * cookie-blocker.js (see AFixt/cookie-banner#69).
+ * @module cookie-blocker-rules
+ */
+
+// Common tracking script patterns to block
+export const TRACKING_PATTERNS = [
+  /google-analytics\.com/,
+  /googletagmanager\.com/,
+  /doubleclick\.net/,
+  /facebook\.net/,
+  /facebook\.com.*\/tr/,
+  /twitter\.com.*\/analytics/,
+  /linkedin\.com.*\/analytics/,
+  /hotjar\.com/,
+  /mixpanel\.com/,
+  /segment\.com/,
+  /amplitude\.com/,
+  /fullstory\.com/,
+  /_ga_/,
+  /_gid/,
+  /_gat/,
+  /fbp/,
+  /fbc/,
+];
+
+// Cookie patterns to block by category
+export const COOKIE_PATTERNS = {
+  analytics: [
+    /^_ga/,
+    /^_gid/,
+    /^_gat/,
+    /^_utm/,
+    /^__utma/,
+    /^__utmb/,
+    /^__utmc/,
+    /^__utmt/,
+    /^__utmz/,
+    /^_dc_gtm/,
+  ],
+  marketing: [
+    /^_fbp/,
+    /^_fbc/,
+    /^fr/,
+    /^tr/,
+    /^IDE/,
+    /^test_cookie/,
+    /^ads-id/,
+    /^_gcl_/,
+    /^__Secure-3PAPISID/,
+    /^__Secure-3PSID/,
+  ],
+  social: [/^__twitter_sess/, /^li_at/, /^li_gc/, /^bcookie/, /^bscookie/, /^lang/, /^lidc/],
+};
+
+const INLINE_TRACKING_PATTERNS = [/ga\s*\(/, /gtag\s*\(/, /_gaq\./, /fbq\s*\(/, /dataLayer\.push/];
+
+/**
+ * Check if inline script content contains tracking code
+ * @param {string} content - Script content to check
+ * @returns {boolean} Whether the content matches a tracking pattern
+ */
+export function matchesInlineTracking(content) {
+  return INLINE_TRACKING_PATTERNS.some(pattern => pattern.test(content));
+}
+
+/**
+ * Get the tracking keyword from inline script content
+ * @param {string} content - Script content
+ * @returns {string} The tracking keyword found
+ */
+export function getTrackingKeyword(content) {
+  const patterns = {
+    'ga(': /ga\s*\(/,
+    'gtag(': /gtag\s*\(/,
+    _gaq: /_gaq\./,
+    'fbq(': /fbq\s*\(/,
+    'dataLayer.push': /dataLayer\.push/,
+  };
+
+  for (const [keyword, pattern] of Object.entries(patterns)) {
+    if (pattern.test(content)) {
+      return keyword;
+    }
+  }
+
+  return 'tracking code';
+}
+
+/**
+ * Get the category of a script based on its URL
+ * @param {string} src - Script source URL
+ * @returns {string} The script category ('analytics' or 'marketing')
+ */
+export function getScriptCategory(src) {
+  if (!src) {
+    return 'analytics';
+  }
+
+  if (src.match(/google-analytics|googletagmanager|_ga|_gid|_gat/i)) {
+    return 'analytics';
+  } else if (src.match(/facebook|twitter|linkedin|doubleclick/i)) {
+    return 'marketing';
+  }
+
+  return 'analytics'; // Default to analytics
+}
+
+/**
+ * Decide whether a cookie should be blocked given the current consent
+ * manager. Pure with respect to module state — the caller supplies the
+ * consent manager (or null when consent has not been given yet).
+ * @param {string} cookieName - Name of the cookie to check
+ * @param {Object|null} consentManager - window.CookieConsent or null
+ * @returns {boolean} Whether the cookie should be blocked
+ */
+export function cookieBlockDecision(cookieName, consentManager) {
+  // If no consent yet, block all non-functional cookies
+  if (!consentManager) {
+    return !cookieName.startsWith('cookie-consent'); // Allow our own consent cookie
+  }
+
+  // Check against pattern categories
+  for (const [category, patterns] of Object.entries(COOKIE_PATTERNS)) {
+    const hasConsent = consentManager.hasConsent ? consentManager.hasConsent(category) : false;
+    if (!hasConsent && patterns.some(pattern => pattern.test(cookieName))) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+/**
+ * Decide whether a script URL should be blocked given the current consent
+ * manager. Pure with respect to module state.
+ * @param {string} src - Script source URL to check
+ * @param {Object|null} consentManager - window.CookieConsent or null
+ * @returns {boolean} Whether the script should be blocked
+ */
+export function scriptBlockDecision(src, consentManager) {
+  // If no consent manager or no consent yet, block all tracking scripts
+  if (!consentManager || !consentManager.hasConsent) {
+    return TRACKING_PATTERNS.some(pattern => pattern.test(src));
+  }
+
+  // Get the script category based on pattern matching
+  let scriptCategory = null;
+  if (src.match(/google-analytics|googletagmanager|_ga|_gid|_gat/i)) {
+    scriptCategory = 'analytics';
+  } else if (src.match(/facebook|twitter|linkedin|doubleclick/i)) {
+    scriptCategory = 'marketing';
+  }
+
+  // Check consent for the category
+  if (scriptCategory && !consentManager.hasConsent(scriptCategory)) {
+    return true;
+  }
+
+  // Default: block if matches any tracking pattern and no consent
+  return TRACKING_PATTERNS.some(pattern => pattern.test(src));
+}

--- a/src/js/cookie-blocker.js
+++ b/src/js/cookie-blocker.js
@@ -5,6 +5,21 @@
  * @version 1.0.0
  */
 
+import {
+  matchesInlineTracking,
+  cookieBlockDecision,
+  scriptBlockDecision,
+} from './cookie-blocker-rules.js';
+import {
+  overrideCreateElement,
+  overrideAppendMethods,
+  overrideSetAttribute,
+  restoreDomOverrides,
+  createElementBypassingBlock,
+  appendChildBypassingBlock,
+} from './cookie-blocker-dom.js';
+import { overrideCookieProperty, blockExistingCookies } from './cookie-blocker-cookies.js';
+
 // See banner.js for why the IIFE result is captured into a module-level
 // binding and re-exported: Rollup tree-shakes side-effect-only IIFE imports
 // out of the published bundle. The exported binding below is what guarantees
@@ -12,64 +27,18 @@
 const _blockerAPI = (function () {
   'use strict';
 
-  // Common tracking script patterns to block
-  const TRACKING_PATTERNS = [
-    /google-analytics\.com/,
-    /googletagmanager\.com/,
-    /doubleclick\.net/,
-    /facebook\.net/,
-    /facebook\.com.*\/tr/,
-    /twitter\.com.*\/analytics/,
-    /linkedin\.com.*\/analytics/,
-    /hotjar\.com/,
-    /mixpanel\.com/,
-    /segment\.com/,
-    /amplitude\.com/,
-    /fullstory\.com/,
-    /_ga_/,
-    /_gid/,
-    /_gat/,
-    /fbp/,
-    /fbc/,
-  ];
-
-  // Cookie patterns to block by category
-  const COOKIE_PATTERNS = {
-    analytics: [
-      /^_ga/,
-      /^_gid/,
-      /^_gat/,
-      /^_utm/,
-      /^__utma/,
-      /^__utmb/,
-      /^__utmc/,
-      /^__utmt/,
-      /^__utmz/,
-      /^_dc_gtm/,
-    ],
-    marketing: [
-      /^_fbp/,
-      /^_fbc/,
-      /^fr/,
-      /^tr/,
-      /^IDE/,
-      /^test_cookie/,
-      /^ads-id/,
-      /^_gcl_/,
-      /^__Secure-3PAPISID/,
-      /^__Secure-3PSID/,
-    ],
-    social: [/^__twitter_sess/, /^li_at/, /^li_gc/, /^bcookie/, /^bscookie/, /^lang/, /^lidc/],
-  };
-
   // Blocked scripts and elements storage
   let blockedScripts = [];
-  let originalCreateElement = null;
-  let originalAppendChild = null;
-  let originalInsertBefore = null;
-  let originalSetAttribute = null;
   let isBlocking = true;
   let isInitialized = false;
+
+  /**
+   * Get the installed consent manager, if any
+   * @returns {Object|null} window.CookieConsent or null
+   */
+  function getConsentManager() {
+    return typeof window !== 'undefined' && window.CookieConsent ? window.CookieConsent : null;
+  }
 
   /**
    * Initialize the cookie blocker - sets up script and cookie blocking mechanisms
@@ -90,39 +59,29 @@ const _blockerAPI = (function () {
 
     isInitialized = true;
 
+    const handlers = {
+      shouldBlockScript,
+      shouldBlockInlineScript,
+      onBlocked: record => blockedScripts.push(record),
+    };
+
     // Block cookies using document.cookie override - do this first
-    overrideCookieProperty();
+    overrideCookieProperty(shouldBlockCookie);
 
     // Block existing cookies on page load
-    blockExistingCookies();
+    blockExistingCookies(shouldBlockCookie);
 
     // Override document.createElement to intercept script creation
-    overrideCreateElement();
+    overrideCreateElement(handlers);
 
     // Override appendChild and insertBefore to intercept script insertion
-    overrideAppendMethods();
+    overrideAppendMethods(handlers);
 
     // Override setAttribute to catch src changes
-    overrideSetAttribute();
+    overrideSetAttribute(handlers);
 
     // Listen for consent changes
     document.addEventListener('cookieConsentChanged', handleConsentChange);
-  }
-
-  /**
-   * Block existing cookies based on patterns
-   */
-  function blockExistingCookies() {
-    const cookies = document.cookie.split(';');
-
-    cookies.forEach(cookie => {
-      const [name] = cookie.trim().split('=');
-      if (shouldBlockCookie(name)) {
-        // Delete the cookie by setting it to expire immediately
-        document.cookie = `${name}=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/; domain=${window.location.hostname}`;
-        document.cookie = `${name}=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/`;
-      }
-    });
   }
 
   /**
@@ -138,28 +97,7 @@ const _blockerAPI = (function () {
     if (!isBlocking) {
       return false;
     }
-
-    const consentManager =
-      typeof window !== 'undefined' && window.CookieConsent ? window.CookieConsent : null;
-
-    // If no consent yet, block all non-functional cookies
-    if (!consentManager) {
-      return !cookieName.startsWith('cookie-consent'); // Allow our own consent cookie
-    }
-
-    // Check against pattern categories
-    for (const [category, patterns] of Object.entries(COOKIE_PATTERNS)) {
-      const hasConsent = consentManager.hasConsent ? consentManager.hasConsent(category) : false;
-      if (!hasConsent) {
-        for (const pattern of patterns) {
-          if (pattern.test(cookieName)) {
-            return true;
-          }
-        }
-      }
-    }
-
-    return false;
+    return cookieBlockDecision(cookieName, getConsentManager());
   }
 
   /**
@@ -175,30 +113,7 @@ const _blockerAPI = (function () {
     if (!isBlocking || !src) {
       return false;
     }
-
-    const consentManager =
-      typeof window !== 'undefined' && window.CookieConsent ? window.CookieConsent : null;
-
-    // If no consent manager or no consent yet, block all tracking scripts
-    if (!consentManager || !consentManager.hasConsent) {
-      return TRACKING_PATTERNS.some(pattern => pattern.test(src));
-    }
-
-    // Get the script category based on pattern matching
-    let scriptCategory = null;
-    if (src.match(/google-analytics|googletagmanager|_ga|_gid|_gat/i)) {
-      scriptCategory = 'analytics';
-    } else if (src.match(/facebook|twitter|linkedin|doubleclick/i)) {
-      scriptCategory = 'marketing';
-    }
-
-    // Check consent for the category
-    if (scriptCategory && !consentManager.hasConsent(scriptCategory)) {
-      return true;
-    }
-
-    // Default: block if matches any tracking pattern and no consent
-    return TRACKING_PATTERNS.some(pattern => pattern.test(src));
+    return scriptBlockDecision(src, getConsentManager());
   }
 
   /**
@@ -211,325 +126,61 @@ const _blockerAPI = (function () {
     if (!isBlocking || !content) {
       return false;
     }
-
-    const inlineTrackingPatterns = [
-      /ga\s*\(/,
-      /gtag\s*\(/,
-      /_gaq\./,
-      /fbq\s*\(/,
-      /dataLayer\.push/,
-    ];
-
-    return inlineTrackingPatterns.some(pattern => pattern.test(content));
+    return matchesInlineTracking(content);
   }
 
   /**
-   * Get the tracking keyword from inline script content
-   * @function
-   * @param {string} content - Script content
-   * @returns {string} The tracking keyword found
+   * Check whether a consent object allows scripts of the given type
+   * @param {string} type - Blocked script category
+   * @param {Object} consent - Consent detail from the change event
+   * @returns {boolean} True when the script may now execute
    */
-  function getTrackingKeyword(content) {
-    const patterns = {
-      'ga(': /ga\s*\(/,
-      'gtag(': /gtag\s*\(/,
-      _gaq: /_gaq\./,
-      'fbq(': /fbq\s*\(/,
-      'dataLayer.push': /dataLayer\.push/,
-    };
+  function consentAllowsType(type, consent) {
+    if (type === 'analytics') {
+      return consent.analytics === true;
+    }
+    if (type === 'marketing') {
+      return consent.marketing === true;
+    }
+    if (type === 'social') {
+      return consent.social === true;
+    }
+    return false;
+  }
 
-    for (const [keyword, pattern] of Object.entries(patterns)) {
-      if (pattern.test(content)) {
-        return keyword;
-      }
+  /**
+   * Re-create and execute a previously blocked script, copying its
+   * attributes, using the original DOM methods so the override is bypassed.
+   * @param {Object} blockedItem - Record captured when the script was blocked
+   */
+  function executeBlockedScript(blockedItem) {
+    const { element, src, innerHTML } = blockedItem;
+
+    console.log('Executing previously blocked script:', src || 'inline script');
+
+    // Create a new script element and load it
+    const newScript = createElementBypassingBlock('script');
+
+    if (src) {
+      newScript.src = src;
+    } else if (innerHTML) {
+      newScript.innerHTML = innerHTML;
     }
 
-    return 'tracking code';
-  }
+    if (element) {
+      newScript.async = element.async || false;
+      newScript.defer = element.defer || false;
 
-  /**
-   * Get the category of a script based on its URL
-   * @function
-   * @param {string} src - Script source URL
-   * @returns {string} The script category ('analytics' or 'marketing')
-   */
-  function getScriptCategory(src) {
-    if (!src) {
-      return 'analytics';
-    }
-
-    if (src.match(/google-analytics|googletagmanager|_ga|_gid|_gat/i)) {
-      return 'analytics';
-    } else if (src.match(/facebook|twitter|linkedin|doubleclick/i)) {
-      return 'marketing';
-    }
-
-    return 'analytics'; // Default to analytics
-  }
-
-  /**
-   * Override document.createElement to intercept script creation
-   */
-  function overrideCreateElement() {
-    originalCreateElement = document.createElement;
-
-    document.createElement = function (tagName) {
-      const element = originalCreateElement.call(this, tagName);
-
-      if (tagName.toLowerCase() === 'script') {
-        // Store reference to check later when src is set
-        element._cookieBannerTracked = true;
-
-        // Store reference to the original src descriptor to properly set src on non-blocked scripts
-        const originalSrcDescriptor = Object.getOwnPropertyDescriptor(
-          HTMLScriptElement.prototype,
-          'src'
-        );
-
-        // Override the src setter
-        let originalSrc = '';
-        Object.defineProperty(element, 'src', {
-          get: function () {
-            return originalSrc;
-          },
-          set: function (value) {
-            originalSrc = value;
-
-            if (shouldBlockScript(value)) {
-              console.log('[Cookie Banner] Blocked script:', value);
-              blockedScripts.push({
-                element: element,
-                src: value,
-                type: 'analytics', // Could be enhanced to detect type
-              });
-              return; // Don't actually set the src
-            }
-
-            // Set the src normally using the original setter
-            if (originalSrcDescriptor && originalSrcDescriptor.set) {
-              originalSrcDescriptor.set.call(element, value);
-            }
-          },
-          configurable: true,
-        });
-      }
-
-      return element;
-    };
-  }
-
-  /**
-   * Override appendChild and insertBefore methods
-   */
-  function overrideAppendMethods() {
-    originalAppendChild = Element.prototype.appendChild;
-    originalInsertBefore = Element.prototype.insertBefore;
-
-    Element.prototype.appendChild = function (child) {
-      if (child && child.tagName === 'SCRIPT') {
-        // Check for manual data-category attribute
-        const dataCategory = child.getAttribute && child.getAttribute('data-category');
-        if (dataCategory) {
-          const consentManager = window.CookieConsent;
-          if (
-            !consentManager ||
-            !consentManager.hasConsent ||
-            !consentManager.hasConsent(dataCategory)
-          ) {
-            console.log('Blocked tracking script:', child.src || 'inline script');
-            // Debug: check data-category scripts
-            blockedScripts.push({
-              element: child,
-              src: child.src,
-              innerHTML: child.innerHTML,
-              type: dataCategory,
-            });
-            return child; // Return the element but don't actually append it
-          }
+      // Copy other attributes
+      Array.from(element.attributes).forEach(attr => {
+        if (attr.name !== 'src') {
+          newScript.setAttribute(attr.name, attr.value);
         }
-        // Check both external scripts and inline scripts
-        else if (child.src && shouldBlockScript(child.src)) {
-          console.log('Blocked tracking script:', child.src);
-          blockedScripts.push({
-            element: child,
-            src: child.src,
-            type: getScriptCategory(child.src),
-          });
-          return child; // Return the element but don't actually append it
-        } else if (child.innerHTML && shouldBlockInlineScript(child.innerHTML)) {
-          console.log(
-            'Blocked inline tracking script containing:',
-            getTrackingKeyword(child.innerHTML)
-          );
-          blockedScripts.push({
-            element: child,
-            innerHTML: child.innerHTML,
-            type: 'analytics',
-          });
-          return child; // Return the element but don't actually append it
-        }
-      }
-      return originalAppendChild.call(this, child);
-    };
-
-    Element.prototype.insertBefore = function (newNode, referenceNode) {
-      if (newNode && newNode.tagName === 'SCRIPT') {
-        // Check for manual data-category attribute
-        const dataCategory = newNode.getAttribute && newNode.getAttribute('data-category');
-        if (dataCategory) {
-          const consentManager = window.CookieConsent;
-          if (
-            !consentManager ||
-            !consentManager.hasConsent ||
-            !consentManager.hasConsent(dataCategory)
-          ) {
-            console.log('Blocked tracking script:', newNode.src || 'inline script');
-            blockedScripts.push({
-              element: newNode,
-              src: newNode.src,
-              innerHTML: newNode.innerHTML,
-              type: dataCategory,
-            });
-            return newNode; // Return the element but don't actually insert it
-          }
-        }
-        // Check both external scripts and inline scripts
-        else if (newNode.src && shouldBlockScript(newNode.src)) {
-          console.log('Blocked tracking script:', newNode.src);
-          blockedScripts.push({
-            element: newNode,
-            src: newNode.src,
-            type: getScriptCategory(newNode.src),
-          });
-          return newNode; // Return the element but don't actually insert it
-        } else if (newNode.innerHTML && shouldBlockInlineScript(newNode.innerHTML)) {
-          console.log(
-            'Blocked inline tracking script containing:',
-            getTrackingKeyword(newNode.innerHTML)
-          );
-          blockedScripts.push({
-            element: newNode,
-            innerHTML: newNode.innerHTML,
-            type: 'analytics',
-          });
-          return newNode; // Return the element but don't actually insert it
-        }
-      }
-      return originalInsertBefore.call(this, newNode, referenceNode);
-    };
-  }
-
-  /**
-   * Override setAttribute to catch dynamic src changes
-   */
-  function overrideSetAttribute() {
-    originalSetAttribute = Element.prototype.setAttribute;
-
-    Element.prototype.setAttribute = function (name, value) {
-      if (this.tagName === 'SCRIPT' && name === 'src' && shouldBlockScript(value)) {
-        console.log('[Cookie Banner] Blocked script setAttribute:', value);
-        blockedScripts.push({
-          element: this,
-          src: value,
-          type: 'analytics',
-        });
-        return; // Don't set the attribute
-      }
-      return originalSetAttribute.call(this, name, value);
-    };
-  }
-
-  /**
-   * Override document.cookie property to block cookie setting
-   */
-  function overrideCookieProperty() {
-    // Check if cookie property has already been overridden by us
-    if (document._cookieBlockerOverridden) {
-      return;
-    }
-
-    // Get the original cookie descriptor - try different locations
-    let originalDescriptor =
-      Object.getOwnPropertyDescriptor(Document.prototype, 'cookie') ||
-      Object.getOwnPropertyDescriptor(HTMLDocument.prototype, 'cookie');
-
-    // If no descriptor found in prototypes, check document directly
-    if (!originalDescriptor) {
-      originalDescriptor = Object.getOwnPropertyDescriptor(document, 'cookie');
-      // If document.cookie is a simple value property (e.g., in test environment)
-      if (!originalDescriptor || (!originalDescriptor.get && !originalDescriptor.set)) {
-        // Create a backup storage and wrap the simple property
-        let cookieStorage = document.cookie || '';
-        originalDescriptor = {
-          get: function () {
-            return cookieStorage;
-          },
-          set: function (value) {
-            // Simulate real cookie behavior
-            if (value) {
-              const [cookiePart] = value.split(';');
-              const [name, val] = cookiePart.split('=');
-              if (name && val) {
-                // Simple cookie storage simulation
-                const cookies = cookieStorage ? cookieStorage.split('; ') : [];
-                const updated = cookies.filter(c => !c.startsWith(name + '='));
-                updated.push(cookiePart.trim());
-                cookieStorage = updated.join('; ');
-              }
-            }
-            return value;
-          },
-          configurable: true,
-        };
-      }
-    }
-
-    if (!originalDescriptor || !originalDescriptor.set) {
-      console.warn('[Cookie Banner] Could not find valid cookie descriptor');
-      return;
-    }
-
-    try {
-      // Store the original getter and setter
-      const originalGet = originalDescriptor.get || (() => '');
-      const originalSet = originalDescriptor.set;
-
-      Object.defineProperty(document, 'cookie', {
-        configurable: true,
-        enumerable: true,
-        get: function () {
-          try {
-            return originalGet.call(this);
-          } catch (error) {
-            console.error('[Cookie Banner] Error getting cookie:', error.message);
-            return '';
-          }
-        },
-        set: function (value) {
-          try {
-            const [cookieString] = value.split(';');
-            const [name] = cookieString.split('=');
-
-            if (shouldBlockCookie(name.trim())) {
-              console.log('Blocked cookie:', cookieString.trim());
-              return; // Don't actually set the cookie
-            }
-
-            originalSet.call(this, value);
-          } catch (error) {
-            // Fail closed: do not set the cookie if blocking logic errors (L4)
-            console.error('[Cookie Banner] Error in cookie blocking logic:', error.message);
-            return;
-          }
-        },
       });
-
-      // Mark as overridden
-      document._cookieBlockerOverridden = true;
-    } catch (e) {
-      // Property may already be defined or not configurable
-      console.warn('[Cookie Banner] Could not override cookie property:', e.message);
     }
+
+    // Add to document using original appendChild to bypass our override
+    appendChildBypassingBlock(document.head || document.body, newScript);
   }
 
   /**
@@ -544,46 +195,9 @@ const _blockerAPI = (function () {
 
     // Load previously blocked scripts based on new consent
     blockedScripts.forEach(blockedItem => {
-      const { element, src, innerHTML, type } = blockedItem;
-
       // Only unblock if explicit consent is granted for this script type
-      let shouldUnblock;
-      if (type === 'analytics') {
-        shouldUnblock = consent.analytics === true;
-      } else if (type === 'marketing') {
-        shouldUnblock = consent.marketing === true;
-      } else if (type === 'social') {
-        shouldUnblock = consent.social === true;
-      } else {
-        shouldUnblock = false;
-      }
-
-      if (shouldUnblock) {
-        console.log('Executing previously blocked script:', src || 'inline script');
-
-        // Create a new script element and load it
-        const newScript = originalCreateElement.call(document, 'script');
-
-        if (src) {
-          newScript.src = src;
-        } else if (innerHTML) {
-          newScript.innerHTML = innerHTML;
-        }
-
-        if (element) {
-          newScript.async = element.async || false;
-          newScript.defer = element.defer || false;
-
-          // Copy other attributes
-          Array.from(element.attributes).forEach(attr => {
-            if (attr.name !== 'src') {
-              newScript.setAttribute(attr.name, attr.value);
-            }
-          });
-        }
-
-        // Add to document using original appendChild to bypass our override
-        originalAppendChild.call(document.head || document.body, newScript);
+      if (consentAllowsType(blockedItem.type, consent)) {
+        executeBlockedScript(blockedItem);
       }
     });
 
@@ -626,22 +240,7 @@ const _blockerAPI = (function () {
    */
   function resetCookieBlocker() {
     // Restore original methods if they were overridden
-    if (originalCreateElement) {
-      document.createElement = originalCreateElement;
-      originalCreateElement = null;
-    }
-    if (originalAppendChild) {
-      Element.prototype.appendChild = originalAppendChild;
-      originalAppendChild = null;
-    }
-    if (originalInsertBefore) {
-      Element.prototype.insertBefore = originalInsertBefore;
-      originalInsertBefore = null;
-    }
-    if (originalSetAttribute) {
-      Element.prototype.setAttribute = originalSetAttribute;
-      originalSetAttribute = null;
-    }
+    restoreDomOverrides();
 
     // Reset state
     blockedScripts = [];

--- a/src/js/subdomain-sync-html.js
+++ b/src/js/subdomain-sync-html.js
@@ -1,0 +1,81 @@
+/**
+ * @fileoverview Generator for the static sync-endpoint HTML page that the
+ * primary domain hosts for postMessage-based consent synchronization.
+ * Extracted from subdomain-sync.js (see AFixt/cookie-banner#69).
+ * @module subdomain-sync-html
+ */
+
+import { isValidDomain, filterValidSubdomains } from './subdomain-sync-validation.js';
+
+/**
+ * Create sync endpoint HTML file content
+ * @param {Object} config - Sync configuration (primaryDomain, allowedSubdomains)
+ * @returns {string} HTML content for the sync endpoint
+ */
+export function buildSyncEndpointHTML(config) {
+  // Validate all config values before embedding in HTML to prevent XSS (C1)
+  if (!isValidDomain(config.primaryDomain)) {
+    console.error('[Cookie Banner] Cannot generate sync HTML: invalid primaryDomain');
+    return '';
+  }
+
+  // Build the allowed domains list safely using only validated values
+  const validSubdomains = filterValidSubdomains(config.allowedSubdomains);
+  const allowedDomains = validSubdomains.map(s => s + '.' + config.primaryDomain);
+  allowedDomains.push(config.primaryDomain);
+
+  // Use JSON.stringify for safe injection into script context
+  const domainsJSON = JSON.stringify(allowedDomains);
+
+  return `<!DOCTYPE html>
+<html>
+<head>
+  <title>Cookie Consent Sync</title>
+  <meta charset="utf-8">
+</head>
+<body>
+<script>
+(function() {
+  'use strict';
+
+  var ALLOWED_DOMAINS = ${domainsJSON};
+
+  var CONSENT_KEY = 'cookieConsent';
+
+  window.addEventListener('message', function(event) {
+    var origin;
+    try {
+      origin = new URL(event.origin).hostname;
+    } catch (e) {
+      return;
+    }
+    // Use exact domain matching only (H4)
+    if (ALLOWED_DOMAINS.indexOf(origin) === -1) {
+      return;
+    }
+
+    if (!event.data || !event.data.type) {
+      return;
+    }
+
+    switch (event.data.type) {
+      case 'CONSENT_SYNC_REQUEST':
+        var consent = localStorage.getItem(CONSENT_KEY);
+        event.source.postMessage({
+          type: 'CONSENT_SYNC_RESPONSE',
+          consent: consent ? JSON.parse(consent) : null
+        }, event.origin);
+        break;
+
+      case 'CONSENT_SYNC_UPDATE':
+        if (event.data.consent) {
+          localStorage.setItem(CONSENT_KEY, JSON.stringify(event.data.consent));
+        }
+        break;
+    }
+  });
+})();
+</script>
+</body>
+</html>`;
+}

--- a/src/js/subdomain-sync-validation.js
+++ b/src/js/subdomain-sync-validation.js
@@ -1,0 +1,147 @@
+/**
+ * @fileoverview Validation and configuration preparation for subdomain
+ * consent synchronization: domain/subdomain patterns, consent schema checks,
+ * endpoint vetting, and config sanitization. Extracted from
+ * subdomain-sync.js (see AFixt/cookie-banner#69).
+ * @module subdomain-sync-validation
+ */
+
+/** Minimum allowed sync interval in ms */
+export const MIN_SYNC_INTERVAL = 1000;
+
+/** Strict domain name pattern */
+const DOMAIN_REGEX = /^[a-z0-9]([a-z0-9-]*[a-z0-9])?(\.[a-z0-9]([a-z0-9-]*[a-z0-9])?)*$/i;
+
+/** Single-label subdomain pattern */
+const SUBDOMAIN_REGEX = /^[a-z0-9]([a-z0-9-]*[a-z0-9])?$/i;
+
+/** Allowed config keys to prevent prototype pollution. `currentHostname` is a
+ *  documented test-only override consumed by `getCurrentHostname()`. */
+const ALLOWED_SYNC_CONFIG_KEYS = [
+  'enabled',
+  'primaryDomain',
+  'allowedSubdomains',
+  'syncEndpoint',
+  'syncInterval',
+  'usePostMessage',
+  'currentHostname',
+];
+
+/**
+ * Validate a domain name against a strict pattern
+ * @param {string} domain - Domain to validate
+ * @returns {boolean} Whether the domain is valid
+ */
+export function isValidDomain(domain) {
+  return typeof domain === 'string' && DOMAIN_REGEX.test(domain) && domain.length <= 253;
+}
+
+/**
+ * Keep only syntactically valid single-label subdomains
+ * @param {Array} subdomains - Candidate subdomain list
+ * @returns {string[]} Valid subdomains
+ */
+export function filterValidSubdomains(subdomains) {
+  return (subdomains || []).filter(s => typeof s === 'string' && SUBDOMAIN_REGEX.test(s));
+}
+
+/**
+ * Sanitize config by allowlisting known keys and validating values
+ * @param {Object} userConfig - User-provided configuration
+ * @returns {Object} Sanitized configuration
+ */
+export function sanitizeConfig(userConfig) {
+  const sanitized = {};
+  for (const key of ALLOWED_SYNC_CONFIG_KEYS) {
+    if (Object.prototype.hasOwnProperty.call(userConfig, key)) {
+      sanitized[key] = userConfig[key];
+    }
+  }
+  return sanitized;
+}
+
+/**
+ * Validate a consent object against expected schema
+ * @param {Object} obj - Object to validate
+ * @returns {Object|null} Validated consent or null
+ */
+export function validateConsentSchema(obj) {
+  if (typeof obj !== 'object' || obj === null || Array.isArray(obj)) {
+    return null;
+  }
+  return {
+    functional: obj.functional === true,
+    analytics: obj.analytics === true,
+    marketing: obj.marketing === true,
+    timestamp: typeof obj.timestamp === 'string' ? obj.timestamp : null,
+  };
+}
+
+/**
+ * Validate that a sync endpoint URL is safe: HTTPS and on the primary domain
+ * or an allowed subdomain of it.
+ * @param {string} endpoint - URL to validate
+ * @param {Object} config - Sync configuration (primaryDomain, allowedSubdomains)
+ * @returns {boolean} Whether the endpoint is valid
+ */
+export function isValidSyncEndpoint(endpoint, config) {
+  try {
+    const url = new URL(endpoint);
+    if (url.protocol !== 'https:') {
+      console.error('[Cookie Banner] Sync endpoint must use HTTPS');
+      return false;
+    }
+    const validDomains = [
+      config.primaryDomain,
+      ...config.allowedSubdomains.map(s => s + '.' + config.primaryDomain),
+    ];
+    if (!validDomains.some(d => url.hostname === d)) {
+      console.error('[Cookie Banner] Sync endpoint must be on an allowed domain');
+      return false;
+    }
+    return true;
+  } catch (e) {
+    console.error('[Cookie Banner] Invalid sync endpoint URL:', e.message);
+    return false;
+  }
+}
+
+/**
+ * Merge, sanitize, and validate a user config against the defaults.
+ * Normalizes the subdomain list, clamps the sync interval, and drops an
+ * invalid endpoint. Reports a status the initializer maps to its logging
+ * and early-return behavior.
+ * @param {Object} userConfig - User-provided configuration
+ * @param {Object} defaultConfig - Module defaults
+ * @returns {{config: Object, status: string}} Prepared config and one of
+ *   'disabled' | 'invalid-domain' | 'ok'
+ */
+export function prepareSyncConfig(userConfig, defaultConfig) {
+  const config = { ...defaultConfig, ...sanitizeConfig(userConfig) };
+
+  if (!config.enabled || !config.primaryDomain) {
+    return { config, status: 'disabled' };
+  }
+
+  // Validate primaryDomain format
+  if (!isValidDomain(config.primaryDomain)) {
+    return { config, status: 'invalid-domain' };
+  }
+
+  // Validate allowedSubdomains entries
+  if (Array.isArray(config.allowedSubdomains)) {
+    config.allowedSubdomains = filterValidSubdomains(config.allowedSubdomains);
+  }
+
+  // Enforce minimum sync interval
+  if (typeof config.syncInterval === 'number' && config.syncInterval < MIN_SYNC_INTERVAL) {
+    config.syncInterval = MIN_SYNC_INTERVAL;
+  }
+
+  // Validate sync endpoint if provided
+  if (config.syncEndpoint && !isValidSyncEndpoint(config.syncEndpoint, config)) {
+    config.syncEndpoint = null;
+  }
+
+  return { config, status: 'ok' };
+}

--- a/src/js/subdomain-sync.js
+++ b/src/js/subdomain-sync.js
@@ -5,6 +5,13 @@
  * @version 1.0.0
  */
 
+import {
+  prepareSyncConfig,
+  validateConsentSchema,
+  isValidSyncEndpoint,
+} from './subdomain-sync-validation.js';
+import { buildSyncEndpointHTML } from './subdomain-sync-html.js';
+
 // See banner.js for why the IIFE result is captured into a module-level
 // binding and re-exported.
 const _subdomainSyncAPI = (function () {
@@ -21,24 +28,6 @@ const _subdomainSyncAPI = (function () {
    * @property {boolean} usePostMessage - Use postMessage for iframe communication
    */
 
-  /** Minimum allowed sync interval in ms */
-  const MIN_SYNC_INTERVAL = 1000;
-
-  /** Strict domain name pattern */
-  const DOMAIN_REGEX = /^[a-z0-9]([a-z0-9-]*[a-z0-9])?(\.[a-z0-9]([a-z0-9-]*[a-z0-9])?)*$/i;
-
-  /** Allowed config keys to prevent prototype pollution. `currentHostname` is a
-   *  documented test-only override consumed by `getCurrentHostname()`. */
-  const ALLOWED_SYNC_CONFIG_KEYS = [
-    'enabled',
-    'primaryDomain',
-    'allowedSubdomains',
-    'syncEndpoint',
-    'syncInterval',
-    'usePostMessage',
-    'currentHostname',
-  ];
-
   const defaultConfig = {
     enabled: false,
     primaryDomain: null,
@@ -53,107 +42,22 @@ const _subdomainSyncAPI = (function () {
   let syncInterval = null;
 
   /**
-   * Validate a domain name against a strict pattern
-   * @param {string} domain - Domain to validate
-   * @returns {boolean} Whether the domain is valid
-   */
-  function isValidDomain(domain) {
-    return typeof domain === 'string' && DOMAIN_REGEX.test(domain) && domain.length <= 253;
-  }
-
-  /**
-   * Sanitize config by allowlisting known keys and validating values
-   * @param {Object} userConfig - User-provided configuration
-   * @returns {Object} Sanitized configuration
-   */
-  function sanitizeConfig(userConfig) {
-    const sanitized = {};
-    for (const key of ALLOWED_SYNC_CONFIG_KEYS) {
-      if (Object.prototype.hasOwnProperty.call(userConfig, key)) {
-        sanitized[key] = userConfig[key];
-      }
-    }
-    return sanitized;
-  }
-
-  /**
-   * Validate a consent object against expected schema
-   * @param {Object} obj - Object to validate
-   * @returns {Object|null} Validated consent or null
-   */
-  function validateConsentSchema(obj) {
-    if (typeof obj !== 'object' || obj === null || Array.isArray(obj)) {
-      return null;
-    }
-    return {
-      functional: obj.functional === true,
-      analytics: obj.analytics === true,
-      marketing: obj.marketing === true,
-      timestamp: typeof obj.timestamp === 'string' ? obj.timestamp : null,
-    };
-  }
-
-  /**
-   * Validate that a sync endpoint URL is safe
-   * @param {string} endpoint - URL to validate
-   * @returns {boolean} Whether the endpoint is valid
-   */
-  function isValidSyncEndpoint(endpoint) {
-    try {
-      const url = new URL(endpoint);
-      if (url.protocol !== 'https:') {
-        console.error('[Cookie Banner] Sync endpoint must use HTTPS');
-        return false;
-      }
-      const validDomains = [
-        config.primaryDomain,
-        ...config.allowedSubdomains.map(s => s + '.' + config.primaryDomain),
-      ];
-      if (!validDomains.some(d => url.hostname === d)) {
-        console.error('[Cookie Banner] Sync endpoint must be on an allowed domain');
-        return false;
-      }
-      return true;
-    } catch (e) {
-      console.error('[Cookie Banner] Invalid sync endpoint URL:', e.message);
-      return false;
-    }
-  }
-
-  /**
    * Initialize subdomain consent synchronization
    * @param {SubdomainSyncConfig} userConfig - Configuration options
    * @returns {void}
    */
   function initSubdomainSync(userConfig = {}) {
-    config = { ...defaultConfig, ...sanitizeConfig(userConfig) };
+    const prepared = prepareSyncConfig(userConfig, defaultConfig);
+    config = prepared.config;
 
-    if (!config.enabled || !config.primaryDomain) {
+    if (prepared.status === 'disabled') {
       console.log('[Cookie Banner] Subdomain sync disabled or no primary domain configured');
       return;
     }
 
-    // Validate primaryDomain format
-    if (!isValidDomain(config.primaryDomain)) {
+    if (prepared.status === 'invalid-domain') {
       console.error('[Cookie Banner] Invalid primaryDomain format');
       return;
-    }
-
-    // Validate allowedSubdomains entries
-    if (Array.isArray(config.allowedSubdomains)) {
-      config.allowedSubdomains = config.allowedSubdomains.filter(
-        s => typeof s === 'string' && /^[a-z0-9]([a-z0-9-]*[a-z0-9])?$/i.test(s)
-      );
-    }
-
-    // Enforce minimum sync interval
-    if (typeof config.syncInterval === 'number' && config.syncInterval < MIN_SYNC_INTERVAL) {
-      config.syncInterval = MIN_SYNC_INTERVAL;
-    }
-
-    // Validate sync endpoint if provided
-    if (config.syncEndpoint && !isValidSyncEndpoint(config.syncEndpoint)) {
-      config.syncEndpoint = null;
     }
 
     // Validate current domain is allowed
@@ -358,11 +262,19 @@ const _subdomainSyncAPI = (function () {
   }
 
   /**
+   * Check the configured endpoint is present and still valid before use
+   * @returns {boolean}
+   */
+  function hasValidEndpoint() {
+    return !!config.syncEndpoint && isValidSyncEndpoint(config.syncEndpoint, config);
+  }
+
+  /**
    * Fetch consent from API endpoint
    * @returns {Promise<void>}
    */
   async function fetchConsentFromAPI() {
-    if (!config.syncEndpoint || !isValidSyncEndpoint(config.syncEndpoint)) {
+    if (!hasValidEndpoint()) {
       return;
     }
 
@@ -390,7 +302,7 @@ const _subdomainSyncAPI = (function () {
    * @returns {Promise<void>}
    */
   async function pushConsentToAPI(consent) {
-    if (!config.syncEndpoint || !isValidSyncEndpoint(config.syncEndpoint)) {
+    if (!hasValidEndpoint()) {
       return;
     }
 
@@ -416,73 +328,7 @@ const _subdomainSyncAPI = (function () {
    * @returns {string} HTML content for the sync endpoint
    */
   function generateSyncEndpointHTML() {
-    // Validate all config values before embedding in HTML to prevent XSS (C1)
-    if (!isValidDomain(config.primaryDomain)) {
-      console.error('[Cookie Banner] Cannot generate sync HTML: invalid primaryDomain');
-      return '';
-    }
-
-    // Build the allowed domains list safely using only validated values
-    const validSubdomains = (config.allowedSubdomains || []).filter(
-      s => typeof s === 'string' && /^[a-z0-9]([a-z0-9-]*[a-z0-9])?$/i.test(s)
-    );
-    const allowedDomains = validSubdomains.map(s => s + '.' + config.primaryDomain);
-    allowedDomains.push(config.primaryDomain);
-
-    // Use JSON.stringify for safe injection into script context
-    const domainsJSON = JSON.stringify(allowedDomains);
-
-    return `<!DOCTYPE html>
-<html>
-<head>
-  <title>Cookie Consent Sync</title>
-  <meta charset="utf-8">
-</head>
-<body>
-<script>
-(function() {
-  'use strict';
-
-  var ALLOWED_DOMAINS = ${domainsJSON};
-
-  var CONSENT_KEY = 'cookieConsent';
-
-  window.addEventListener('message', function(event) {
-    var origin;
-    try {
-      origin = new URL(event.origin).hostname;
-    } catch (e) {
-      return;
-    }
-    // Use exact domain matching only (H4)
-    if (ALLOWED_DOMAINS.indexOf(origin) === -1) {
-      return;
-    }
-
-    if (!event.data || !event.data.type) {
-      return;
-    }
-
-    switch (event.data.type) {
-      case 'CONSENT_SYNC_REQUEST':
-        var consent = localStorage.getItem(CONSENT_KEY);
-        event.source.postMessage({
-          type: 'CONSENT_SYNC_RESPONSE',
-          consent: consent ? JSON.parse(consent) : null
-        }, event.origin);
-        break;
-
-      case 'CONSENT_SYNC_UPDATE':
-        if (event.data.consent) {
-          localStorage.setItem(CONSENT_KEY, JSON.stringify(event.data.consent));
-        }
-        break;
-    }
-  });
-})();
-</script>
-</body>
-</html>`;
+    return buildSyncEndpointHTML(config);
   }
 
   /**

--- a/test/banner-focus.test.js
+++ b/test/banner-focus.test.js
@@ -1,0 +1,100 @@
+/**
+ * Unit tests for banner-focus.js — modal focus capture, restore, and the
+ * Tab/Shift+Tab trap. Extracted units from #69.
+ */
+
+const { createFocusManager } = require('../src/js/banner-focus.js');
+
+describe('banner-focus', () => {
+  let manager;
+  let modal;
+  let outsideButton;
+  let first;
+  let last;
+
+  beforeEach(() => {
+    document.body.innerHTML = `
+      <button id="outside">outside</button>
+      <div id="modal">
+        <button id="first">first</button>
+        <input id="middle" type="checkbox" />
+        <button id="last">last</button>
+      </div>
+    `;
+    manager = createFocusManager();
+    modal = document.getElementById('modal');
+    outsideButton = document.getElementById('outside');
+    first = document.getElementById('first');
+    last = document.getElementById('last');
+  });
+
+  function tabEvent(shiftKey) {
+    return {
+      key: 'Tab',
+      shiftKey,
+      preventDefault: jest.fn(),
+    };
+  }
+
+  test('captureFocus records the active element and focuses the first focusable', () => {
+    outsideButton.focus();
+    manager.captureFocus(modal);
+    expect(document.activeElement).toBe(first);
+
+    manager.restoreFocus();
+    expect(document.activeElement).toBe(outsideButton);
+  });
+
+  test('a remembered trigger wins over the active element and resets after restore', () => {
+    manager.rememberTrigger(outsideButton);
+    document.getElementById('middle').focus();
+    manager.captureFocus(modal);
+
+    manager.restoreFocus();
+    expect(document.activeElement).toBe(outsideButton);
+
+    // Second restore is a no-op: the remembered element was cleared
+    first.focus();
+    manager.restoreFocus();
+    expect(document.activeElement).toBe(first);
+  });
+
+  test('Tab on the last element wraps focus to the first', () => {
+    manager.captureFocus(modal);
+    last.focus();
+
+    const event = tabEvent(false);
+    manager.trapFocus(event);
+
+    expect(event.preventDefault).toHaveBeenCalled();
+    expect(document.activeElement).toBe(first);
+  });
+
+  test('Shift+Tab on the first element wraps focus to the last', () => {
+    manager.captureFocus(modal);
+    first.focus();
+
+    const event = tabEvent(true);
+    manager.trapFocus(event);
+
+    expect(event.preventDefault).toHaveBeenCalled();
+    expect(document.activeElement).toBe(last);
+  });
+
+  test('Tab in the middle of the dialog is left alone', () => {
+    manager.captureFocus(modal);
+    document.getElementById('middle').focus();
+
+    const event = tabEvent(false);
+    manager.trapFocus(event);
+
+    expect(event.preventDefault).not.toHaveBeenCalled();
+  });
+
+  test('non-Tab keys are ignored', () => {
+    manager.captureFocus(modal);
+    const event = { key: 'Enter', shiftKey: false, preventDefault: jest.fn() };
+    manager.trapFocus(event);
+    expect(event.preventDefault).not.toHaveBeenCalled();
+  });
+});

--- a/test/banner-storage.test.js
+++ b/test/banner-storage.test.js
@@ -1,0 +1,124 @@
+/**
+ * Unit tests for banner-storage.js — consent validation, secure cookie
+ * construction, and storage read/write. Extracted units from #69.
+ */
+
+const {
+  validateConsentData,
+  buildSecureCookie,
+  readStoredConsent,
+  writeStoredConsent,
+} = require('../src/js/banner-storage.js');
+
+describe('banner-storage', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    document.cookie = 'cookieConsent=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/';
+    console.error = jest.fn();
+  });
+
+  describe('validateConsentData', () => {
+    test('returns null for non-objects, null, and arrays', () => {
+      expect(validateConsentData('consent')).toBeNull();
+      expect(validateConsentData(null)).toBeNull();
+      expect(validateConsentData([true, true])).toBeNull();
+      expect(validateConsentData(42)).toBeNull();
+    });
+
+    test('coerces non-boolean category values to false', () => {
+      const result = validateConsentData({
+        functional: 'yes',
+        analytics: 1,
+        marketing: true,
+      });
+      expect(result).toEqual({
+        functional: false,
+        analytics: false,
+        marketing: true,
+        timestamp: null,
+      });
+    });
+
+    test('keeps a string timestamp and rejects other types', () => {
+      const iso = '2026-01-01T00:00:00.000Z';
+      expect(validateConsentData({ timestamp: iso }).timestamp).toBe(iso);
+      expect(validateConsentData({ timestamp: 12345 }).timestamp).toBeNull();
+    });
+  });
+
+  describe('buildSecureCookie', () => {
+    test('builds a SameSite=Lax cookie string without Secure on http', () => {
+      // jsdom test environment serves http://localhost
+      const cookie = buildSecureCookie('name', 'value', 'Thu, 01 Jan 2026 00:00:00 GMT');
+      expect(cookie).toBe(
+        'name=value; expires=Thu, 01 Jan 2026 00:00:00 GMT; path=/; SameSite=Lax'
+      );
+      expect(cookie).not.toContain('Secure');
+    });
+  });
+
+  describe('readStoredConsent', () => {
+    test('reads and validates consent from localStorage', () => {
+      localStorage.setItem(
+        'cookieConsent',
+        JSON.stringify({ functional: true, analytics: true, marketing: false })
+      );
+      expect(readStoredConsent('localStorage')).toEqual({
+        functional: true,
+        analytics: true,
+        marketing: false,
+        timestamp: null,
+      });
+    });
+
+    test('returns null when nothing is stored', () => {
+      expect(readStoredConsent('localStorage')).toBeNull();
+    });
+
+    test('reads consent from a cookie when configured for cookies', () => {
+      document.cookie = `cookieConsent=${encodeURIComponent(
+        JSON.stringify({ functional: true, analytics: false, marketing: false })
+      )}`;
+      expect(readStoredConsent('cookie')).toEqual({
+        functional: true,
+        analytics: false,
+        marketing: false,
+        timestamp: null,
+      });
+    });
+
+    test('returns null and logs on corrupt stored JSON', () => {
+      localStorage.setItem('cookieConsent', '{not json');
+      expect(readStoredConsent('localStorage')).toBeNull();
+      expect(console.error).toHaveBeenCalledWith('Error retrieving consent:', expect.anything());
+    });
+
+    test('rejects stored values that are not consent-shaped', () => {
+      localStorage.setItem('cookieConsent', JSON.stringify(['a', 'b']));
+      expect(readStoredConsent('localStorage')).toBeNull();
+    });
+  });
+
+  describe('writeStoredConsent', () => {
+    test('forces functional true and stamps a timestamp', () => {
+      const stored = writeStoredConsent(
+        { functional: false, analytics: true, marketing: false },
+        { storageMethod: 'localStorage', expireDays: 365 }
+      );
+      expect(stored.functional).toBe(true);
+      expect(typeof stored.timestamp).toBe('string');
+      expect(JSON.parse(localStorage.getItem('cookieConsent'))).toEqual(stored);
+    });
+
+    test('writes to document.cookie when configured for cookies', () => {
+      writeStoredConsent(
+        { analytics: false, marketing: true },
+        { storageMethod: 'cookie', expireDays: 1 }
+      );
+      expect(document.cookie).toContain('cookieConsent=');
+      const roundTripped = readStoredConsent('cookie');
+      expect(roundTripped.marketing).toBe(true);
+      expect(roundTripped.functional).toBe(true);
+    });
+  });
+});

--- a/test/cookie-blocker-rules.test.js
+++ b/test/cookie-blocker-rules.test.js
@@ -1,0 +1,84 @@
+/**
+ * Unit tests for cookie-blocker-rules.js — the pure classification rules
+ * behind the cookie blocker. Extracted units from #69.
+ */
+
+const {
+  cookieBlockDecision,
+  scriptBlockDecision,
+  matchesInlineTracking,
+  getTrackingKeyword,
+  getScriptCategory,
+} = require('../src/js/cookie-blocker-rules.js');
+
+describe('cookie-blocker-rules', () => {
+  describe('cookieBlockDecision', () => {
+    test('without a consent manager, blocks everything except the consent cookie', () => {
+      expect(cookieBlockDecision('_ga', null)).toBe(true);
+      expect(cookieBlockDecision('random_cookie', null)).toBe(true);
+      expect(cookieBlockDecision('cookie-consent-state', null)).toBe(false);
+    });
+
+    test('blocks category cookies when that category lacks consent', () => {
+      const manager = { hasConsent: category => category === 'marketing' };
+      expect(cookieBlockDecision('_ga', manager)).toBe(true); // analytics denied
+      expect(cookieBlockDecision('_fbp', manager)).toBe(false); // marketing granted
+    });
+
+    test('allows unmatched cookies when a consent manager exists', () => {
+      const manager = { hasConsent: () => false };
+      expect(cookieBlockDecision('session_id', manager)).toBe(false);
+    });
+
+    test('treats a manager without hasConsent as denying every category', () => {
+      expect(cookieBlockDecision('_gid', {})).toBe(true);
+    });
+  });
+
+  describe('scriptBlockDecision', () => {
+    const GA_SRC = 'https://www.google-analytics.com/analytics.js';
+    const FB_SRC = 'https://connect.facebook.net/en_US/fbevents.js';
+
+    test('without a consent manager, blocks tracking scripts by pattern', () => {
+      expect(scriptBlockDecision(GA_SRC, null)).toBe(true);
+      expect(scriptBlockDecision('https://example.com/app.js', null)).toBe(false);
+    });
+
+    test('blocks a category script when its category lacks consent', () => {
+      const manager = { hasConsent: () => false };
+      expect(scriptBlockDecision(GA_SRC, manager)).toBe(true);
+      expect(scriptBlockDecision(FB_SRC, manager)).toBe(true);
+    });
+
+    test('non-tracking scripts pass through with a consent manager present', () => {
+      const manager = { hasConsent: () => false };
+      expect(scriptBlockDecision('https://example.com/app.js', manager)).toBe(false);
+    });
+  });
+
+  describe('matchesInlineTracking', () => {
+    test('detects common inline tracking snippets', () => {
+      expect(matchesInlineTracking("ga('send', 'pageview');")).toBe(true);
+      expect(matchesInlineTracking("gtag('config', 'UA-1');")).toBe(true);
+      expect(matchesInlineTracking('dataLayer.push({});')).toBe(true);
+      expect(matchesInlineTracking('console.log("hello");')).toBe(false);
+    });
+  });
+
+  describe('getTrackingKeyword', () => {
+    test('names the matched tracker', () => {
+      expect(getTrackingKeyword("ga('send');")).toBe('ga(');
+      expect(getTrackingKeyword("fbq('track');")).toBe('fbq(');
+      expect(getTrackingKeyword('nothing here')).toBe('tracking code');
+    });
+  });
+
+  describe('getScriptCategory', () => {
+    test('classifies analytics and marketing hosts, defaulting to analytics', () => {
+      expect(getScriptCategory('https://www.googletagmanager.com/gtm.js')).toBe('analytics');
+      expect(getScriptCategory('https://connect.facebook.net/fbevents.js')).toBe('marketing');
+      expect(getScriptCategory('https://example.com/app.js')).toBe('analytics');
+      expect(getScriptCategory('')).toBe('analytics');
+    });
+  });
+});

--- a/test/subdomain-sync-validation.test.js
+++ b/test/subdomain-sync-validation.test.js
@@ -1,0 +1,136 @@
+/**
+ * Unit tests for subdomain-sync-validation.js — domain/endpoint vetting and
+ * sync config preparation. Extracted units from #69.
+ */
+
+const {
+  MIN_SYNC_INTERVAL,
+  isValidDomain,
+  filterValidSubdomains,
+  sanitizeConfig,
+  validateConsentSchema,
+  isValidSyncEndpoint,
+  prepareSyncConfig,
+} = require('../src/js/subdomain-sync-validation.js');
+
+const DEFAULTS = {
+  enabled: false,
+  primaryDomain: null,
+  allowedSubdomains: [],
+  syncEndpoint: null,
+  syncInterval: 5000,
+  usePostMessage: true,
+};
+
+describe('subdomain-sync-validation', () => {
+  beforeEach(() => {
+    console.error = jest.fn();
+  });
+
+  describe('isValidDomain', () => {
+    test('accepts well-formed domains', () => {
+      expect(isValidDomain('example.com')).toBe(true);
+      expect(isValidDomain('sub.example.co.uk')).toBe(true);
+    });
+
+    test('rejects malformed values', () => {
+      expect(isValidDomain('-bad.com')).toBe(false);
+      expect(isValidDomain('exa mple.com')).toBe(false);
+      expect(isValidDomain('a'.repeat(254))).toBe(false);
+      expect(isValidDomain(42)).toBe(false);
+    });
+  });
+
+  describe('filterValidSubdomains', () => {
+    test('keeps single labels and drops injection attempts', () => {
+      expect(filterValidSubdomains(['app', 'www2', 'evil.com', '<script>', 7, null])).toEqual([
+        'app',
+        'www2',
+      ]);
+      expect(filterValidSubdomains(undefined)).toEqual([]);
+    });
+  });
+
+  describe('sanitizeConfig', () => {
+    test('drops keys outside the allowlist (prototype pollution guard)', () => {
+      const sanitized = sanitizeConfig({
+        enabled: true,
+        primaryDomain: 'example.com',
+        __proto__: { polluted: true },
+        constructor: 'x',
+        extraneous: 'y',
+      });
+      expect(sanitized).toEqual({ enabled: true, primaryDomain: 'example.com' });
+    });
+  });
+
+  describe('validateConsentSchema', () => {
+    test('normalizes shapes and rejects non-objects', () => {
+      expect(validateConsentSchema(null)).toBeNull();
+      expect(validateConsentSchema([])).toBeNull();
+      expect(validateConsentSchema({ analytics: true })).toEqual({
+        functional: false,
+        analytics: true,
+        marketing: false,
+        timestamp: null,
+      });
+    });
+  });
+
+  describe('isValidSyncEndpoint', () => {
+    const config = { primaryDomain: 'example.com', allowedSubdomains: ['app'] };
+
+    test('accepts https endpoints on the primary domain or allowed subdomains', () => {
+      expect(isValidSyncEndpoint('https://example.com/sync', config)).toBe(true);
+      expect(isValidSyncEndpoint('https://app.example.com/sync', config)).toBe(true);
+    });
+
+    test('rejects http, foreign hosts, and unparseable URLs', () => {
+      expect(isValidSyncEndpoint('http://example.com/sync', config)).toBe(false);
+      expect(isValidSyncEndpoint('https://evil.com/sync', config)).toBe(false);
+      expect(isValidSyncEndpoint('not a url', config)).toBe(false);
+      expect(console.error).toHaveBeenCalledTimes(3);
+    });
+  });
+
+  describe('prepareSyncConfig', () => {
+    test('reports disabled when sync is off or the primary domain is missing', () => {
+      expect(prepareSyncConfig({}, DEFAULTS).status).toBe('disabled');
+      expect(prepareSyncConfig({ enabled: true }, DEFAULTS).status).toBe('disabled');
+    });
+
+    test('reports invalid-domain for a malformed primary domain', () => {
+      const prepared = prepareSyncConfig({ enabled: true, primaryDomain: 'bad domain' }, DEFAULTS);
+      expect(prepared.status).toBe('invalid-domain');
+    });
+
+    test('filters subdomains, clamps the interval, and drops a bad endpoint', () => {
+      const prepared = prepareSyncConfig(
+        {
+          enabled: true,
+          primaryDomain: 'example.com',
+          allowedSubdomains: ['app', 'evil.com'],
+          syncInterval: 10,
+          syncEndpoint: 'http://example.com/sync',
+        },
+        DEFAULTS
+      );
+      expect(prepared.status).toBe('ok');
+      expect(prepared.config.allowedSubdomains).toEqual(['app']);
+      expect(prepared.config.syncInterval).toBe(MIN_SYNC_INTERVAL);
+      expect(prepared.config.syncEndpoint).toBeNull();
+    });
+
+    test('keeps a valid https endpoint on an allowed domain', () => {
+      const prepared = prepareSyncConfig(
+        {
+          enabled: true,
+          primaryDomain: 'example.com',
+          syncEndpoint: 'https://example.com/consent-sync',
+        },
+        DEFAULTS
+      );
+      expect(prepared.config.syncEndpoint).toBe('https://example.com/consent-sync');
+    });
+  });
+});


### PR DESCRIPTION
## Summary
Fixes #69 (split out of #62).

Splits the three largest source files into focused modules with **no behavioral change** — all 176 pre-existing tests pass unmodified, and every console message / public API surface is preserved verbatim:

| Before | After |
|---|---|
| `banner.js` (482 sloc) | orchestrator + `banner-dom.js`, `banner-storage.js`, `banner-focus.js` |
| `cookie-blocker.js` (468 sloc) | coordinator + `cookie-blocker-rules.js`, `cookie-blocker-dom.js`, `cookie-blocker-cookies.js` |
| `subdomain-sync.js` (331 sloc) | orchestrator + `subdomain-sync-validation.js`, `subdomain-sync-html.js` |

Notable duplication removed: the three identical consent-application blocks in `addEventListeners` (banner), and the twin 45-line `appendChild`/`insertBefore` interception blocks (cookie-blocker).

## Acceptance criteria from #69
- ✅ All three files under 300 lines / split into focused modules
- ✅ No function over 75 lines or cyclomatic complexity 10 (`createModal`, `addEventListeners`, `overrideAppendMethods`, `shouldBlockScript`, `overrideCookieProperty`, `initSubdomainSync` all decomposed)
- ✅ 38 new unit tests for extracted units; coverage 75.6% → **84.7%** statements (subdomain-sync validation and cookie-blocker rules now at 100%)
- ✅ `max-lines`, `max-lines-per-function`, `complexity`, `max-depth`, `max-params`, `max-nested-callbacks` enabled in `eslint.config.mjs` for `src/**` — lands green
- ✅ `npm run check` and `npm test` pass with rules enabled
- ✅ No behavioral change — existing tests pass unmodified

## Testing
- 214/214 tests pass; lint/format/css/md/jscpd clean; build succeeds; size-limit within budget