### PR TITLE
fix(examples): Ship locales with the demos, drop unservable markup pages

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -73,8 +73,10 @@ export default {
         // to them for the same reason consent.js does. See issue #72.
         { src: 'src/css/banner.css', dest: `${outputDir}/examples` },
         { src: 'src/locales/*', dest: `${outputDir}/locales` },
-        { src: 'src/html/banner.html', dest: `${outputDir}/examples` },
-        { src: 'src/html/preferences-modal.html', dest: `${outputDir}/examples` },
+        // The bundle fetches `locales/<locale>.json` relative to the page, so
+        // the language-switch demos need a copy under dist/examples/ too.
+        // See issue #86.
+        { src: 'src/locales/*', dest: `${outputDir}/examples/locales` },
         { src: 'examples/*', dest: `${outputDir}/examples` },
         { src: 'src/types', dest: `${outputDir}` },
         { src: 'README.md', dest: outputDir },

--- a/test/example-script-paths.test.js
+++ b/test/example-script-paths.test.js
@@ -12,9 +12,14 @@
  * https://github.com/AFixt/cookie-banner/issues/72 and
  * https://github.com/AFixt/cookie-banner/issues/86.
  *
- * banner.html and preferences-modal.html are also copied into dist/examples/
- * from src/html/, where their relative paths do resolve; they are markup
- * references rather than runnable examples, so they are not covered here.
+ * The bundle also fetches `locales/<locale>.json` relative to the page, so
+ * the build copies src/locales/ next to the pages as dist/examples/locales/;
+ * without it the language-switch demos silently fall back to English.
+ *
+ * src/html/banner.html and preferences-modal.html are markup references, not
+ * runnable examples: their `../js/*.js` and `../css/banner.css` references
+ * only resolve inside the source tree, so they are no longer copied into
+ * dist/examples/.
  */
 
 const fs = require('fs');
@@ -80,6 +85,18 @@ describe('rollup copies the assets next to the examples', () => {
       /src:\s*[`'"][^`'"]*banner\.css[`'"],\s*dest:\s*[`'"][^`'"]*examples[`'"]/
     );
   });
+
+  it('copies the locales so locales/<locale>.json resolves from the pages', () => {
+    expect(rollupConfig).toMatch(
+      /src:\s*[`'"][^`'"]*locales\/\*[`'"],\s*dest:\s*[`'"][^`'"]*examples\/locales[`'"]/
+    );
+  });
+
+  it('does not ship the src/html markup references as examples', () => {
+    // Their ../js and ../css references only resolve from src/html/, so a
+    // copy under dist/examples/ 404s every asset it loads.
+    expect(rollupConfig).not.toMatch(/src:\s*[`'"]src\/html\//);
+  });
 });
 
 // Only meaningful after `npm run build`; dist/ is gitignored and absent on a
@@ -104,5 +121,18 @@ const BUILT_DIR = path.join(ROOT, 'dist', 'examples');
       scriptSrcs(fs.readFileSync(path.join(BUILT_DIR, page), 'utf8'))
     );
     expect(all.length).toBeGreaterThan(0);
+  });
+
+  it('ships every locale next to the pages so the language switchers work', () => {
+    const sourceLocales = fs.readdirSync(path.join(ROOT, 'src', 'locales'));
+    expect(sourceLocales.length).toBeGreaterThan(0);
+    sourceLocales.forEach(locale => {
+      expect(fs.existsSync(path.join(BUILT_DIR, 'locales', locale))).toBe(true);
+    });
+  });
+
+  it('does not ship the src/html markup references', () => {
+    expect(fs.existsSync(path.join(BUILT_DIR, 'banner.html'))).toBe(false);
+    expect(fs.existsSync(path.join(BUILT_DIR, 'preferences-modal.html'))).toBe(false);
   });
 });


### PR DESCRIPTION
Supersedes #90, which was auto-closed when the base branch of #87 was deleted and cannot be reopened after the rebase onto `develop`. Same change, now based cleanly on `develop` (single commit).

Fixes the two residual `dist/examples/` issues left after #87.

## 1. Language-switch demos always fell back to English

`banner.js` fetches `locales/<locale>.json` relative to the page, but rollup only copied the locales to `dist/locales/`. From `dist/examples/` that fetch 404s, so the fr/es selectors in `vanilla-js.html` and `rtl-support.html` warned and stayed English.

**Fix:** copy `src/locales/*` to `dist/examples/locales/` as well.

## 2. `banner.html` / `preferences-modal.html` 404 every asset from `dist/examples/`

They reference `../js/consent-manager.js`, `../js/banner.js`, and `../css/banner.css`, which only resolve inside the source tree — and `banner.html` also calls `new ConsentManager()`, a global the UMD bundle never defines (the same pattern #87's tests forbid in example pages). Rewriting them into runnable demos would just duplicate `vanilla-js.html`, so they are markup references, not examples.

**Fix:** stop copying them into `dist/examples/`; `npm run build` cleans `dist/` first, so no stale copies survive.

## Test guards (`test/example-script-paths.test.js`)

- rollup config must copy `src/locales/*` to an `examples/locales` dest
- rollup config must not copy anything from `src/html/`
- post-build: `dist/examples/locales/` contains every file from `src/locales/`
- post-build: `banner.html` and `preferences-modal.html` are absent from `dist/examples/`

## Verification

- Rebased onto `develop` after #87 and #91 merged; clean rebase, no conflicts
- `npm run build && npm test` (Node 24.15.0): 16 suites, 243 tests pass
- `dist/examples/locales/` contains de/en/es/fr/it; the two markup pages are absent
- Negative check: removing `dist/examples/locales/` makes the new guard fail