### PR TITLE
build(tooling): Close remaining tooling-stack gaps from #62

### DIFF
--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -1,0 +1,40 @@
+name: Link Check
+
+on:
+  schedule:
+    # Weekly, Monday 06:30 UTC — external links rot on their own schedule,
+    # not per-commit, so this is not a PR gate.
+    - cron: '30 6 * * 1'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  lychee:
+    name: Check Markdown links
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Run lychee
+        id: lychee
+        uses: lycheeverse/lychee-action@v2
+        with:
+          args: >-
+            --no-progress
+            --exclude-path node_modules
+            --exclude-path dist
+            --exclude-path CHANGELOG.md
+            './**/*.md'
+          fail: false
+
+      - name: Open an issue when links are broken
+        if: steps.lychee.outputs.exit_code != 0
+        uses: peter-evans/create-issue-from-file@v5
+        with:
+          title: 'Link check: broken links found'
+          content-filepath: ./lychee/out.md
+          labels: documentation

--- a/.husky/post-merge
+++ b/.husky/post-merge
@@ -1,0 +1,5 @@
+# Keep node_modules in sync after pulls that change the lockfile.
+if git diff --name-only HEAD@{1} HEAD 2>/dev/null | grep -q '^package-lock.json$'; then
+  echo "package-lock.json changed — running npm install to sync node_modules."
+  npm install
+fi

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,2 +1,1 @@
-npm run check
-npm test
+npm run check:all

--- a/README.md
+++ b/README.md
@@ -281,8 +281,15 @@ Supports all modern browsers, including:
 ## Development
 
 ```bash
+# Use the pinned Node version (matches CI)
+nvm use
+
 # Install dependencies
 npm install
+
+# Optional: install external scanner binaries (gitleaks, semgrep,
+# osv-scanner, lychee) used by local gates and scheduled scans
+npm run bootstrap
 
 # Run development server
 npm run dev
@@ -290,9 +297,18 @@ npm run dev
 # Run tests
 npm test
 
+# Full local quality gate: lint, formatting, CSS/Markdown lint,
+# duplication, license allowlist, and the test suite. The pre-push
+# hook runs exactly this, so run it before pushing.
+npm run check:all
+
 # Build for production
 npm run build
 ```
+
+Tooling decisions (what is enforced locally vs. in CI, and why) are
+documented in [docs/adr/](docs/adr/). Templates for new READMEs and ADRs
+live in [docs/templates/](docs/templates/).
 
 ## License
 

--- a/docs/adr/0001-tooling-stack-decisions.md
+++ b/docs/adr/0001-tooling-stack-decisions.md
@@ -1,0 +1,82 @@
+# ADR 0001: Tooling stack decisions for issue #62
+
+Date: 2026-07-22
+
+## Status
+
+Accepted
+
+## Context
+
+Issue #62 proposes a standardized quality, security, accessibility, and
+performance tooling stack. Its ground rule: **do not replace anything that
+already exists unless the new proposal leads to a demonstrably higher quality
+outcome.** Much of the stack landed earlier via #68 (Husky hooks, commitlint,
+lint-staged, Prettier, Stylelint, markdownlint, jscpd, size-limit, gitleaks,
+`.editorconfig`). This ADR records the keep/replace/skip decisions for the
+remainder.
+
+## Decisions
+
+### Kept as-is (existing tool serves the purpose)
+
+- **Jest + Testing Library** over Vitest. The suite (16 files, 239 tests,
+  jsdom, coverage thresholds) is healthy; migration is churn without a
+  quality win for a browser library with no Vite build.
+- **Plain JavaScript with JSDoc** over TypeScript + `ts-reset`. The library
+  is a small, framework-free browser bundle whose public API is documented
+  with JSDoc (now lint-enforced via `eslint-plugin-jsdoc`). A TS migration
+  is a rewrite of every module and test for type coverage that
+  `checkJs`-style tooling can approximate later if wanted. Revisit if the
+  API surface grows.
+- **ESLint (flat config)** — extended rather than replaced (no Biome; issue
+  itself excludes it).
+- **markdownlint-cli** over `markdownlint-cli2` — same engine, config
+  already in place; no quality difference for this repo's needs.
+- **Playwright visual/a11y tests** and the axe-based accessibility suite
+  remain the a11y layers. `@afix/a11y-assert` is a private scoped package;
+  adopting it is deferred until it is available to this repo's CI without
+  friction (tracked in #62).
+
+### Added (gaps closed by this change)
+
+- **ESLint plugins** applicable to vanilla JS: `sonarjs` (code smells,
+  cognitive complexity), `security`, `promise`, `import-x`, `jsdoc`
+  (documentation enforcement on `src/**`), `no-secrets` (second layer
+  behind gitleaks), and a targeted subset of `unicorn`. React-specific
+  plugins are omitted (no React).
+- **`license-checker-rseidelsohn`** allowlist scan at pre-push
+  (`npm run lint:licenses`).
+- **`npm run check:all`** aggregate gate; pre-push now runs it.
+- **`scripts/bootstrap.sh`** installs the optional external binaries
+  (semgrep, osv-scanner, gitleaks, lychee).
+- **lychee** link checking as a weekly scheduled workflow (external-link
+  rot) — local runs are optional because the binary is not npm-installable.
+- **`typescript` (devDependency, 5.9 line)** — present only because
+  `eslint-plugin-sonarjs` requires the TS API at lint time. Pinned to ~5.9:
+  TypeScript 7 changes the compiler API and breaks `ts-api-utils`.
+
+### Skipped, with reasons
+
+- **Dependabot config** (issue asks to commit one): the repository owner
+  removed Dependabot deliberately on 2026-07-22 (PR #85) in favor of manual
+  dependency maintenance. Owner decision supersedes the issue item.
+- **Lighthouse CI budgets**: no deployed preview or page to audit — this is
+  a library, not a site. `size-limit` covers the bundle budget. Revisit if
+  a docs site ships.
+- **OWASP ZAP baseline**: same reason — nothing deployed to scan.
+- **Express hardening items** (helmet, rate-limit, zod, etc.): there is no
+  server in this repo.
+- **Semgrep/OSV/CodeQL as blocking local hooks**: they need external
+  binaries contributors may not have. They are installable via
+  `scripts/bootstrap.sh`; CI keeps CodeQL and OWASP Dependency-Check on
+  schedule in `security.yml`.
+- **TypeDoc**: JSDoc-to-markdown (`npm run docs`) already generates API
+  docs from the same comments.
+
+## Consequences
+
+Local gates catch quality, security-smell, documentation, duplication, and
+license issues before push. CI remains the safety net for scheduled/heavy
+scans. The lint warning budget (jsdoc descriptions, security hints) is
+advisory: errors gate, warnings guide.

--- a/docs/templates/adr-template.md
+++ b/docs/templates/adr-template.md
@@ -1,0 +1,23 @@
+# ADR NNNN: Title
+
+Date: YYYY-MM-DD
+
+## Status
+
+Proposed | Accepted | Deprecated | Superseded by ADR-NNNN
+
+## Context
+
+What is the issue that we're seeing that is motivating this decision or
+change? Describe the forces at play: technical, organizational, and
+budgetary. Stay neutral — this section states facts, not the choice.
+
+## Decision
+
+What is the change that we're proposing and/or doing? Use active voice:
+"We will …". List rejected alternatives and why they lost.
+
+## Consequences
+
+What becomes easier or more difficult because of this change? Include the
+negative consequences — every decision has them.

--- a/docs/templates/readme-template.md
+++ b/docs/templates/readme-template.md
@@ -1,0 +1,42 @@
+# Project Name
+
+One-paragraph description: what this is, who it is for, and the single most
+important thing to know about it.
+
+## Installation
+
+```bash
+npm install package-name
+```
+
+Note any peer dependencies, required Node version (see `.nvmrc`), and
+required external binaries.
+
+## Usage
+
+The smallest possible working example, then the most common real-world
+configuration. Link to full API docs rather than duplicating them.
+
+```js
+// minimal example
+```
+
+## Scripts
+
+| Script | Purpose |
+| --- | --- |
+| `npm test` | Run the test suite |
+| `npm run check:all` | Full local quality gate (lint, format, tests, build) |
+| `npm run build` | Produce distributable bundles |
+
+## Accessibility
+
+State the conformance target (e.g. WCAG 2.2 AA) and how it is verified.
+
+## Contributing
+
+Link to `CONTRIBUTING.md`. Note the branching model and commit conventions.
+
+## License
+
+Name the license and link to the `LICENSE` file.

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,9 +1,19 @@
 import js from '@eslint/js';
 import globals from 'globals';
+import sonarjs from 'eslint-plugin-sonarjs';
+import security from 'eslint-plugin-security';
+import unicorn from 'eslint-plugin-unicorn';
+import importX from 'eslint-plugin-import-x';
+import promise from 'eslint-plugin-promise';
+import jsdoc from 'eslint-plugin-jsdoc';
+import noSecrets from 'eslint-plugin-no-secrets';
 
 /** @type {import('eslint').Linter.Config[]} */
 export default [
   js.configs.recommended,
+  sonarjs.configs.recommended,
+  promise.configs['flat/recommended'],
+  importX.flatConfigs.recommended,
   {
     languageOptions: {
       ecmaVersion: 'latest',
@@ -13,6 +23,9 @@ export default [
         ...globals.browser,
         ...globals.jest,
       },
+    },
+    plugins: {
+      'no-secrets': noSecrets,
     },
     rules: {
       // Code quality
@@ -27,23 +40,82 @@ export default [
       'no-eval': 'error',
       'no-implied-eval': 'error',
       'no-new-func': 'error',
+      'no-secrets/no-secrets': ['error', { tolerance: 4.5 }],
 
       // Best practices
       eqeqeq: ['error', 'always'],
       curly: ['warn', 'all'],
+
+      // Import hygiene (resolution is exercised by Jest and Rollup; the
+      // lint-time resolver does not understand explicit .js ESM specifiers)
+      'import-x/no-unresolved': 'off',
+      'import-x/order': ['warn', { 'newlines-between': 'ignore' }],
+
+      // sonarjs adjustments: duplication is enforced by jscpd with thresholds,
+      // and the cognitive-complexity budget mirrors the complexity rule below
+      'sonarjs/cognitive-complexity': ['error', 15],
+      'sonarjs/no-duplicate-string': 'off',
+
+      // The library returns its promise chains to the caller; the final
+      // then() legitimately produces no value.
+      'promise/always-return': ['error', { ignoreLastCallback: true }],
     },
   },
   {
-    // Size and complexity limits (see #62/#69). Source only — test files
-    // legitimately hold long describe blocks and fixture-heavy functions.
-    files: ['src/**/*.js'],
+    // Test-suite pragmatics: the Playwright visual tests wait on fixed
+    // timers for render stability by design, and consolidating similar
+    // cases into parameterized tests is a style choice, not a defect.
+    files: ['test/**/*.js'],
     rules: {
+      'sonarjs/no-fixed-wait-in-tests': 'off',
+      'sonarjs/parameterized-tests': 'off',
+      'sonarjs/todo-tag': 'warn',
+    },
+  },
+  {
+    // Source-only rules: the published library code is held to a stricter
+    // bar than tests and config (see #62/#69).
+    files: ['src/**/*.js'],
+    plugins: {
+      security,
+      unicorn,
+      jsdoc,
+    },
+    rules: {
+      // Size and complexity limits (see #62/#69). Source only — test files
+      // legitimately hold long describe blocks and fixture-heavy functions.
       'max-lines': ['error', { max: 300, skipBlankLines: true, skipComments: true }],
       'max-lines-per-function': ['error', { max: 75, skipBlankLines: true, skipComments: true }],
       complexity: ['error', 10],
       'max-depth': ['error', 4],
       'max-params': ['error', 4],
       'max-nested-callbacks': ['error', 3],
+
+      // Node/browser security smells
+      ...security.configs.recommended.rules,
+      // The blocker modules match cookie names against fixed pattern tables;
+      // there is no user-controlled RegExp construction.
+      'security/detect-non-literal-regexp': 'off',
+      'security/detect-object-injection': 'off',
+
+      // Modern JS patterns — targeted subset; the full unicorn preset is too
+      // opinionated for this codebase (abbreviations, null usage, etc.)
+      'unicorn/prefer-query-selector': 'warn',
+      'unicorn/prefer-add-event-listener': 'error',
+      'unicorn/no-array-for-each': 'off',
+      'unicorn/prefer-modern-dom-apis': 'warn',
+      'unicorn/no-document-cookie': 'off', // cookie interception is the product
+      'unicorn/explicit-length-check': 'off',
+
+      // Documentation: every exported/public function keeps meaningful JSDoc
+      ...jsdoc.configs['flat/recommended'].rules,
+      'jsdoc/require-jsdoc': [
+        'warn',
+        { publicOnly: false, require: { FunctionDeclaration: true } },
+      ],
+      'jsdoc/require-param-description': 'warn',
+      'jsdoc/require-returns-description': 'warn',
+      'jsdoc/tag-lines': 'off',
     },
   },
   {

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,6 +26,14 @@
         "babel-jest": "^30.4.1",
         "commit-and-tag-version": "^13.1.0",
         "eslint": "^10.7.0",
+        "eslint-plugin-import-x": "^4.17.1",
+        "eslint-plugin-jsdoc": "^63.2.0",
+        "eslint-plugin-n": "^18.2.2",
+        "eslint-plugin-no-secrets": "^2.3.3",
+        "eslint-plugin-promise": "^7.3.0",
+        "eslint-plugin-security": "^4.0.1",
+        "eslint-plugin-sonarjs": "^4.2.0",
+        "eslint-plugin-unicorn": "^72.0.0",
         "globals": "^17.7.0",
         "http-server": "^14.1.1",
         "husky": "^9.1.7",
@@ -34,6 +42,7 @@
         "jscpd": "^5.0.12",
         "jsdoc": "^4.0.5",
         "jsdoc-to-markdown": "^9.1.3",
+        "license-checker-rseidelsohn": "^4.4.2",
         "lint-staged": "17.1.1",
         "markdownlint-cli": "^0.49.1",
         "playwright": "^1.61.1",
@@ -52,6 +61,7 @@
         "size-limit": "^12.1.0",
         "stylelint": "^17.14.1",
         "stylelint-config-standard": "^40.0.0",
+        "typescript": "~5.9.0",
         "webpack-bundle-analyzer": "^5.3.1"
       },
       "engines": {
@@ -2565,6 +2575,33 @@
         "tslib": "^2.4.0"
       }
     },
+    "node_modules/@es-joy/jsdoccomment": {
+      "version": "0.88.0",
+      "resolved": "https://registry.npmjs.org/@es-joy/jsdoccomment/-/jsdoccomment-0.88.0.tgz",
+      "integrity": "sha512-GK/HL/claLLNo5KG705auIlZMwEtmn88ofSGuLsmVZwKBqMPJhW9DiznYNq07QEqz9BPtA3LBfYImtZmhVvRAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.9",
+        "@typescript-eslint/types": "^8.59.4",
+        "comment-parser": "1.4.7",
+        "esquery": "^1.7.0",
+        "jsdoc-type-pratt-parser": "~7.2.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@es-joy/resolve.exports": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@es-joy/resolve.exports/-/resolve.exports-1.2.0.tgz",
+      "integrity": "sha512-Q9hjxWI5xBM+qW2enxfe8wDKdFWMfd0Z29k5ZJnuBqD/CasY5Zryj09aCA6owbGATWz+39p5uIdaHXpopOcG8g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/@eslint-community/eslint-utils": {
       "version": "4.9.1",
       "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.1.tgz",
@@ -2680,6 +2717,27 @@
       "engines": {
         "node": "^20.19.0 || ^22.13.0 || >=24"
       }
+    },
+    "node_modules/@eslint/css-tree": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@eslint/css-tree/-/css-tree-4.0.4.tgz",
+      "integrity": "sha512-nxMparyhqVWQvadx9x8dIfubfIPOE+X2b2waua8fzdnM9vdp9rgVtwEZlG0TmCwEUz/d/f40fzvO/eqBwdxz0A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mdn-data": "2.28.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@eslint/css-tree/node_modules/mdn-data": {
+      "version": "2.28.1",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.28.1.tgz",
+      "integrity": "sha512-U9w+PzSZ00Z5m9rZ5ARVFL5xOfuCHdKYi/1RRwDCJsboFgJDNT3zT6PIPD7mZQYaQLhsZM3GfDRgSMRHhSmVng==",
+      "dev": true,
+      "license": "CC0-1.0"
     },
     "node_modules/@eslint/js": {
       "version": "10.0.1",
@@ -3354,6 +3412,32 @@
         "node": ">= 8"
       }
     },
+    "node_modules/@npmcli/fs": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@npmcli/fs/-/fs-3.1.1.tgz",
+      "integrity": "sha512-q9CRWjpHCMIh5sVyefoD1cA7PkvILqCZsnSOEUUivORLjxCO/Irmue2DprETiNgEqktDBZaM1Bi+jrarx1XdCg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "semver": "^7.3.5"
+      },
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@npmcli/fs/node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/@pkgjs/parseargs": {
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
@@ -3635,9 +3719,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3652,9 +3733,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3669,9 +3747,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3686,9 +3761,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3703,9 +3775,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3720,9 +3789,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3737,9 +3803,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3754,9 +3817,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3771,9 +3831,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3788,9 +3845,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3805,9 +3859,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3822,9 +3873,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3839,9 +3887,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4010,6 +4055,19 @@
       "integrity": "sha512-XiMQh7qqVlxZzcVD+kkGMNGMzcTrDMLWI7S4x7z1MkCkbDPrekpZXEUK0eZqZFMuHQg2a2DZOcDIh9o5v3Gonw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@sindresorhus/base62": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/base62/-/base62-1.0.0.tgz",
+      "integrity": "sha512-TeheYy0ILzBEI/CO55CP6zJCSdSWeRtGnHy8U8dWSUH4I68iqTsy7HkMktR4xakThc9jotkPQUXT4ITdbV7cHA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/@sindresorhus/merge-streams": {
       "version": "4.0.0",
@@ -4349,364 +4407,18 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@typescript/typescript-aix-ppc64": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/@typescript/typescript-aix-ppc64/-/typescript-aix-ppc64-7.0.2.tgz",
-      "integrity": "sha512-MTKKkWB7p/0E9xi1d1tHtZ5PiLkGEMIq88pK2CubZjOsLtYTLqhgIgi6zepFa+9GHZ6h05NMCkQxGKiPXMxXtQ==",
-      "cpu": [
-        "ppc64"
-      ],
+    "node_modules/@typescript-eslint/types": {
+      "version": "8.65.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.65.0.tgz",
+      "integrity": "sha512-JSSwWNy+H0E/01jJEM+hrX6N0OFDzFzeIhHFSAS01tlVaevpG8cFyYRPhS5yjGOvBUx3sqQHVMjCL1CAZZMxBg==",
       "dev": true,
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "aix"
-      ],
-      "peer": true,
+      "license": "MIT",
       "engines": {
-        "node": ">=16.20.0"
-      }
-    },
-    "node_modules/@typescript/typescript-darwin-arm64": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/@typescript/typescript-darwin-arm64/-/typescript-darwin-arm64-7.0.2.tgz",
-      "integrity": "sha512-gowzar9MwS/aRWp6f3a4KUqzRjAZjOsmGNCM6LcTgXum+dBfgsBVMN+AgvOCCbguXyick6LJhpBszxMebJ8syA==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=16.20.0"
-      }
-    },
-    "node_modules/@typescript/typescript-darwin-x64": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/@typescript/typescript-darwin-x64/-/typescript-darwin-x64-7.0.2.tgz",
-      "integrity": "sha512-SZ9xZInqApNlNGc9s0W1VSsktYSOe9cFqNOIqmN1Gs8SmkjKZYFt017G4VwPxASInODuAdbTW7sXiFUf893RgA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=16.20.0"
-      }
-    },
-    "node_modules/@typescript/typescript-freebsd-arm64": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/@typescript/typescript-freebsd-arm64/-/typescript-freebsd-arm64-7.0.2.tgz",
-      "integrity": "sha512-W5NH4y/J0plIIS5b2xvTEkU7JFxyqdMAOgf+Ilhl0vHQXKO5dZoxd+C/jEtq56c4F3wk71RB4BMRQ2XdI+bwYQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=16.20.0"
-      }
-    },
-    "node_modules/@typescript/typescript-freebsd-x64": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/@typescript/typescript-freebsd-x64/-/typescript-freebsd-x64-7.0.2.tgz",
-      "integrity": "sha512-UMGDx5sTpzNw3WiPebH7l90IWfJggEd+egHt/q6p7/Cm3zqoV7VxkGXt+3DxPIw8CcmvAB0j3sVVfbhX+M4Tpw==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=16.20.0"
-      }
-    },
-    "node_modules/@typescript/typescript-linux-arm": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-arm/-/typescript-linux-arm-7.0.2.tgz",
-      "integrity": "sha512-gffT3xPz9sR7j/YJExkyPntrI0P2EP9XbOyWzth2/Gs0RstK+90RBcO0ncXoXy/beYll1SXw846Nf2zdnEz0QQ==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=16.20.0"
-      }
-    },
-    "node_modules/@typescript/typescript-linux-arm64": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-arm64/-/typescript-linux-arm64-7.0.2.tgz",
-      "integrity": "sha512-Qh4eU4/y3yDjnfjjyPYihMj5/ODIlmt+Bzu17OI+fiSRDW57QmU5SiN63exPRNJPKUzcc1INa1NXdrJ+MqHjUQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=16.20.0"
-      }
-    },
-    "node_modules/@typescript/typescript-linux-loong64": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-loong64/-/typescript-linux-loong64-7.0.2.tgz",
-      "integrity": "sha512-uEHck9i8hoAzXPiYRib1O7miOnz23SxIeVl6F4LXox+qov1K35jHcEW6VHKvZI+pyvl7fZEP4MCU5LYvIq1GuQ==",
-      "cpu": [
-        "loong64"
-      ],
-      "dev": true,
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=16.20.0"
-      }
-    },
-    "node_modules/@typescript/typescript-linux-mips64el": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-mips64el/-/typescript-linux-mips64el-7.0.2.tgz",
-      "integrity": "sha512-R4KvAMnE43W5Qeqb0Ly56O3mWMWIAgsMyz36DCaycd5nbg/9kzm0liw3JocfRqyJY0KPmzFjbswozXyW0DnIYA==",
-      "cpu": [
-        "mips64el"
-      ],
-      "dev": true,
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=16.20.0"
-      }
-    },
-    "node_modules/@typescript/typescript-linux-ppc64": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-ppc64/-/typescript-linux-ppc64-7.0.2.tgz",
-      "integrity": "sha512-DORx5b3sd/4S7eayxm4FQv+A7CrkUIGRaHiwI8oiHTAI1fAPWhF4J0vAlkC8biAlHSVVwxMQ3tjZ2/DVbnQiiA==",
-      "cpu": [
-        "ppc64"
-      ],
-      "dev": true,
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=16.20.0"
-      }
-    },
-    "node_modules/@typescript/typescript-linux-riscv64": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-riscv64/-/typescript-linux-riscv64-7.0.2.tgz",
-      "integrity": "sha512-wf0jqEDOjrPRnKwYRyyJDRo11KMbvMFrU+q4zqKyChODBzvlkbhNQfKvLxQCcwTpdDaXSHZTVuh0JoCrKCUMHQ==",
-      "cpu": [
-        "riscv64"
-      ],
-      "dev": true,
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=16.20.0"
-      }
-    },
-    "node_modules/@typescript/typescript-linux-s390x": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-s390x/-/typescript-linux-s390x-7.0.2.tgz",
-      "integrity": "sha512-IkwJc3L7yhytWd/ewjyxNDfOmswCm9GWMJT/ue/dU4aZNbwZeYAetq42VyLmsmSjvoX7z74X6ZaYCtzAr0EuGw==",
-      "cpu": [
-        "s390x"
-      ],
-      "dev": true,
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=16.20.0"
-      }
-    },
-    "node_modules/@typescript/typescript-linux-x64": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-x64/-/typescript-linux-x64-7.0.2.tgz",
-      "integrity": "sha512-EYdf2cNg7rgCWJnxCdJ+F3V39O8ihb37eHAu1LK8oAFizgTQbPOK7zHHXbPt8rX24COqODXeI3sIf0fCXG7H/A==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=16.20.0"
-      }
-    },
-    "node_modules/@typescript/typescript-netbsd-arm64": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/@typescript/typescript-netbsd-arm64/-/typescript-netbsd-arm64-7.0.2.tgz",
-      "integrity": "sha512-+polYF4MF04aPpO5FTkHran9yUQDSXqy5GiSDKpsll5jy3l3+g9QLhpf39T+ePtefhXLOGrLl0QIjkQP6VnelA==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "netbsd"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=16.20.0"
-      }
-    },
-    "node_modules/@typescript/typescript-netbsd-x64": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/@typescript/typescript-netbsd-x64/-/typescript-netbsd-x64-7.0.2.tgz",
-      "integrity": "sha512-8YIT0EHM/3dq10ZOVF/A7pc/YSMtbcecct4rWtexrnSCHOPcpC2KTLXfTCR6vDpnSiY12heNb1GiN/wu+T/FyA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "netbsd"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=16.20.0"
-      }
-    },
-    "node_modules/@typescript/typescript-openbsd-arm64": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/@typescript/typescript-openbsd-arm64/-/typescript-openbsd-arm64-7.0.2.tgz",
-      "integrity": "sha512-APT8+ClYnuYm1u9+kgGXoMj2VzWzcymwh2gNSQVySHfkRDGOTVkoWLjCmOQSaO+PoqQ57B0flRp9SA+7GnnkzQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "openbsd"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=16.20.0"
-      }
-    },
-    "node_modules/@typescript/typescript-openbsd-x64": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/@typescript/typescript-openbsd-x64/-/typescript-openbsd-x64-7.0.2.tgz",
-      "integrity": "sha512-yX7s+Q0Dln0Dt9tEzZsAjXXR/+ytBM7AlglaqyeMPxQszJ1JhlJdZ6jLA+IzldHtflX81em7lDao1xXu+aRRkg==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "openbsd"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=16.20.0"
-      }
-    },
-    "node_modules/@typescript/typescript-sunos-x64": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/@typescript/typescript-sunos-x64/-/typescript-sunos-x64-7.0.2.tgz",
-      "integrity": "sha512-dLJDGaLZ1D4HPQn62u1n8mBDkJREwMsAkCdkwd4Ieqw+x3TUyTsqY0YiBCtE6H6OzzgGk3iuZ3vFWRS+E8/d1g==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "sunos"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=16.20.0"
-      }
-    },
-    "node_modules/@typescript/typescript-win32-arm64": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/@typescript/typescript-win32-arm64/-/typescript-win32-arm64-7.0.2.tgz",
-      "integrity": "sha512-Gyl1Vy6OsWesLzmq+EP0Fb7b4Nid5232AvcA2SFcdYreldpNtYFFofPjnt62y9hQy7VTaZp65ICJjuAQRaVcIQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=16.20.0"
-      }
-    },
-    "node_modules/@typescript/typescript-win32-x64": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/@typescript/typescript-win32-x64/-/typescript-win32-x64-7.0.2.tgz",
-      "integrity": "sha512-0BQ3HkAHHlKLSp1qRvf3SUhGpGsDuhB/jgFw75guyqbxJqEaS0Cw/VFO8i2nHglJUzQCRtMMR/IBAKE3ETMC4g==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "Apache-2.0",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "peer": true,
-      "engines": {
-        "node": ">=16.20.0"
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
       }
     },
     "node_modules/@ungap/structured-clone": {
@@ -4822,9 +4534,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4839,9 +4548,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4856,9 +4562,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4873,9 +4576,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4890,9 +4590,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4907,9 +4604,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4924,9 +4618,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4941,9 +4632,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4958,9 +4646,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4975,9 +4660,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5058,6 +4740,16 @@
       "os": [
         "win32"
       ]
+    },
+    "node_modules/abbrev": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-2.0.0.tgz",
+      "integrity": "sha512-6/mh1E2u2YgEsCHdY0Yx5oW+61gZU+1vXaoiHHrpKeuRNNgFvS+/jrwHiQhB5apAf5oB7UB7E19ol2R2LKH8hQ==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
     },
     "node_modules/acorn": {
       "version": "8.16.0",
@@ -5183,6 +4875,16 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/are-docs-informative": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/are-docs-informative/-/are-docs-informative-0.0.2.tgz",
+      "integrity": "sha512-ixiS0nLNNG5jNQzgZJNoUpBKdo9yTYZMGJ+QgT2jmjR7G7+QHRCc4v6LQ3NgE7EBJq+o0ams3waJwkrlBom8Ig==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/argparse": {
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
@@ -5221,6 +4923,16 @@
       "dev": true,
       "engines": {
         "node": ">=12.17"
+      }
+    },
+    "node_modules/array-find-index": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/array-find-index/-/array-find-index-1.0.2.tgz",
+      "integrity": "sha512-M1HQyIXcBGtVywBt8WVdim+lrNaK7VHp99Qt5pSNziXznKHViIBbXWtfRTpEFpF/c4FdfxNAsCCwPp5phBYJtw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/array-union": {
@@ -5540,6 +5252,29 @@
       "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
       "dev": true
     },
+    "node_modules/builtin-modules": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-3.3.0.tgz",
+      "integrity": "sha512-zhaCDicdLuWN5UbN5IMnFqNMhNfo919sH85y2/ea+5Yg9TsTkeZxpL+JLbp6cgYFS4sRLp3YV4S6yDuqVWHYOw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/bytes-iec": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/bytes-iec/-/bytes-iec-3.1.1.tgz",
@@ -5715,6 +5450,13 @@
       "funding": {
         "url": "https://github.com/chalk/chalk-template?sponsor=1"
       }
+    },
+    "node_modules/change-case": {
+      "version": "5.4.4",
+      "resolved": "https://registry.npmjs.org/change-case/-/change-case-5.4.4.tgz",
+      "integrity": "sha512-HRQyTk2/YPEkt9TnUPbOpr64Uw3KOicFWPVBb+xiHvd6eBx/qPr9xqfBFDT8P2vWsvvz4jbEkfDe71W3VyNu2w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/char-regex": {
       "version": "1.0.2",
@@ -5975,6 +5717,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=22.12.0"
+      }
+    },
+    "node_modules/comment-parser": {
+      "version": "1.4.7",
+      "resolved": "https://registry.npmjs.org/comment-parser/-/comment-parser-1.4.7.tgz",
+      "integrity": "sha512-0h+uSNtQGW3D98eQt3jJ8L06Fves8hncB4V/PKdw/Qb8Hnk19VaKuTr55UNRYiSoVa7WwrFls+rh3ux9agmkeQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12.0.0"
       }
     },
     "node_modules/commit-and-tag-version": {
@@ -6260,6 +6012,19 @@
       },
       "engines": {
         "node": ">=22"
+      }
+    },
+    "node_modules/convert-hrtime": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/convert-hrtime/-/convert-hrtime-5.0.0.tgz",
+      "integrity": "sha512-lOETlkIeYSJWcbbcvjRKGxVMXJR+8+OQb/mTPbA4ObPMytYIsUbuOE0Jzy60hjARYszq1id0j8KgVhC+WGZVTg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/convert-source-map": {
@@ -6765,6 +6530,20 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/enhanced-resolve": {
+      "version": "5.24.3",
+      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.24.3.tgz",
+      "integrity": "sha512-PwKooW9JUzh5chmYfHM3IQl5OkK2u2Nm011MgeZrss3JmFraUx/fqrf78kk8GUMYoibx/14MdwTl/1WKkG7TpQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.4",
+        "tapable": "^2.3.3"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
     "node_modules/entities": {
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
@@ -6918,6 +6697,492 @@
         "jiti": {
           "optional": true
         }
+      }
+    },
+    "node_modules/eslint-compat-utils": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/eslint-compat-utils/-/eslint-compat-utils-0.5.1.tgz",
+      "integrity": "sha512-3z3vFexKIEnjHE3zCMRo6fn/e44U7T1khUjg+Hp0ZQMCigh28rALD0nPFBcGZuiLC5rLZa2ubQHDRln09JfU2Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.5.4"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "eslint": ">=6.0.0"
+      }
+    },
+    "node_modules/eslint-compat-utils/node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/eslint-import-context": {
+      "version": "0.1.9",
+      "resolved": "https://registry.npmjs.org/eslint-import-context/-/eslint-import-context-0.1.9.tgz",
+      "integrity": "sha512-K9Hb+yRaGAGUbwjhFNHvSmmkZs9+zbuoe3kFQ4V1wYjrepUFYM2dZAfNtjbbj3qsPfUfsA68Bx/ICWQMi+C8Eg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "get-tsconfig": "^4.10.1",
+        "stable-hash-x": "^0.2.0"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.18.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint-import-context"
+      },
+      "peerDependencies": {
+        "unrs-resolver": "^1.0.0"
+      },
+      "peerDependenciesMeta": {
+        "unrs-resolver": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/eslint-plugin-es-x": {
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-es-x/-/eslint-plugin-es-x-7.8.0.tgz",
+      "integrity": "sha512-7Ds8+wAAoV3T+LAKeu39Y5BzXCrGKrcISfgKEqTS4BDN8SFEDQd0S43jiQ8vIa3wUKD07qitZdfzlenSi8/0qQ==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/ota-meshi",
+        "https://opencollective.com/eslint"
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.1.2",
+        "@eslint-community/regexpp": "^4.11.0",
+        "eslint-compat-utils": "^0.5.1"
+      },
+      "engines": {
+        "node": "^14.18.0 || >=16.0.0"
+      },
+      "peerDependencies": {
+        "eslint": ">=8"
+      }
+    },
+    "node_modules/eslint-plugin-import-x": {
+      "version": "4.17.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-import-x/-/eslint-plugin-import-x-4.17.1.tgz",
+      "integrity": "sha512-4cdstYkKCyjumM2Q9NSI03K8D2a9F4Ssz33K2lv2hQa4KmR9jPLwk3uWGtNvclfqBrPGfGuMBwsGMbe6dMRbfg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "^8.56.0",
+        "comment-parser": "^1.4.1",
+        "debug": "^4.4.1",
+        "eslint-import-context": "^0.1.9",
+        "is-glob": "^4.0.3",
+        "minimatch": "^9.0.3 || ^10.1.2",
+        "semver": "^7.7.2",
+        "stable-hash-x": "^0.2.0",
+        "unrs-resolver": "^1.9.2"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint-plugin-import-x"
+      },
+      "peerDependencies": {
+        "@typescript-eslint/utils": "^8.56.0",
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "eslint-import-resolver-node": "*"
+      },
+      "peerDependenciesMeta": {
+        "@typescript-eslint/utils": {
+          "optional": true
+        },
+        "eslint-import-resolver-node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/eslint-plugin-import-x/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/eslint-plugin-import-x/node_modules/brace-expansion": {
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
+      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/eslint-plugin-import-x/node_modules/minimatch": {
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.5"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/eslint-plugin-import-x/node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/eslint-plugin-jsdoc": {
+      "version": "63.2.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-63.2.0.tgz",
+      "integrity": "sha512-tccz9igEV5mTKVAwo/KwXqKP7ENqa3a+LpRFuEPAP3k/+SXG4T0sOvA+c2wwTD/TLNrH9MCW4LIu4xEExkJdzg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@es-joy/jsdoccomment": "~0.88.0",
+        "@es-joy/resolve.exports": "1.2.0",
+        "are-docs-informative": "^0.0.2",
+        "comment-parser": "1.4.7",
+        "debug": "^4.4.3",
+        "escape-string-regexp": "^4.0.0",
+        "espree": "^11.2.0",
+        "esquery": "^1.7.0",
+        "html-entities": "^2.6.0",
+        "object-deep-merge": "^2.0.1",
+        "parse-imports-exports": "^0.2.4",
+        "semver": "^7.8.5",
+        "spdx-expression-parse": "^4.0.0",
+        "to-valid-identifier": "^1.0.0"
+      },
+      "engines": {
+        "node": "^22.13.0 || >=24"
+      },
+      "peerDependencies": {
+        "eslint": "^7.0.0 || ^8.0.0 || ^9.0.0 || ^10.0.0"
+      }
+    },
+    "node_modules/eslint-plugin-jsdoc/node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/eslint-plugin-n": {
+      "version": "18.2.2",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-n/-/eslint-plugin-n-18.2.2.tgz",
+      "integrity": "sha512-gOO0lIqwEjZ750kv9/SptCWArUoAZXJoBr0vYWTO2dCBxctHUXlBIigiC8xuxxr/NKqgIT6Ehz1xRcilj8a5cA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.5.0",
+        "enhanced-resolve": "^5.17.1",
+        "eslint-plugin-es-x": "^7.8.0",
+        "get-tsconfig": "^4.8.1",
+        "globals": "^15.11.0",
+        "globrex": "^0.1.2",
+        "ignore": "^5.3.2",
+        "semver": "^7.6.3"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      },
+      "peerDependencies": {
+        "eslint": ">=8.57.1",
+        "ts-declaration-location": "^1.0.6",
+        "typescript": ">=5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ts-declaration-location": {
+          "optional": true
+        },
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/eslint-plugin-n/node_modules/globals": {
+      "version": "15.15.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-15.15.0.tgz",
+      "integrity": "sha512-7ACyT3wmyp3I61S4fG682L0VA2RGD9otkqGJIwNUMF1SWUombIIk+af1unuDYgMm082aHYwD+mzJvv9Iu8dsgg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint-plugin-n/node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/eslint-plugin-no-secrets": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-no-secrets/-/eslint-plugin-no-secrets-2.3.3.tgz",
+      "integrity": "sha512-sroCsCscpwQxZ/O9Ml69w5qt/2nvHhXDeyUnSqSC5dMANGxt4rQgUn7xbPvDmhbMPmUCAc2Y3SRU0cXet7kNWQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18",
+        "npm": ">=8"
+      },
+      "peerDependencies": {
+        "eslint": ">=5"
+      }
+    },
+    "node_modules/eslint-plugin-promise": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-promise/-/eslint-plugin-promise-7.3.0.tgz",
+      "integrity": "sha512-6uGiOR0INuujr6PEQmeSSP7GbIMJ/ebEXXiEzb/nOj68LknH5Pxzb/AbZivmr6VE6TkTE8rTjRK9zhKpK6HsRA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.4.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^7.0.0 || ^8.0.0 || ^9.0.0 || ^10.0.0"
+      }
+    },
+    "node_modules/eslint-plugin-security": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-security/-/eslint-plugin-security-4.0.1.tgz",
+      "integrity": "sha512-/lZCkOxPOWaf1jXAqgICrS8St3BMBccIPvhOSUYuV6VCr1o5nFVG998FnTLt6w2Nxb8Uo0nM8fzmnhp+GY/aEg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-regex": "^2.1.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/eslint-plugin-sonarjs": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-sonarjs/-/eslint-plugin-sonarjs-4.2.0.tgz",
+      "integrity": "sha512-bqADfuNtTL7VK6RU29eoiFTtaaBKIpVPuX3bOl+rBpWSBa0zIBVZlqZNZQjfP6s4iXkAJokv5IsD8OsACkwApg==",
+      "dev": true,
+      "license": "LGPL-3.0-only",
+      "dependencies": {
+        "@eslint-community/regexpp": "^4.12.2",
+        "builtin-modules": "^3.3.0",
+        "bytes": "^3.1.2",
+        "functional-red-black-tree": "^1.0.1",
+        "globals": "^17.7.0",
+        "jsx-ast-utils-x": "^0.1.0",
+        "lodash.merge": "^4.6.2",
+        "minimatch": "^10.2.5",
+        "scslre": "^0.3.0",
+        "semver": "^7.8.5",
+        "ts-api-utils": "^2.5.0",
+        "typescript": ">=5 <6.1.0",
+        "yaml": "^2.9.0"
+      },
+      "peerDependencies": {
+        "eslint": "^8.0.0 || ^9.0.0 || ^10.0.0"
+      }
+    },
+    "node_modules/eslint-plugin-sonarjs/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/eslint-plugin-sonarjs/node_modules/brace-expansion": {
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
+      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/eslint-plugin-sonarjs/node_modules/minimatch": {
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.5"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/eslint-plugin-sonarjs/node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/eslint-plugin-sonarjs/node_modules/typescript": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/eslint-plugin-unicorn": {
+      "version": "72.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-unicorn/-/eslint-plugin-unicorn-72.0.0.tgz",
+      "integrity": "sha512-hqO6ksoOHO+ZhdseTuKRVQbx9U7PRO/cv8qAR1mctwzdVO2hYud8uS9luAhp43RJgziYgHAph8eHyipT8GL0ng==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.9.1",
+        "@eslint/css-tree": "^4.0.4",
+        "browserslist": "^4.28.4",
+        "change-case": "^5.4.4",
+        "ci-info": "^4.4.0",
+        "core-js-compat": "^3.49.0",
+        "detect-indent": "^7.0.2",
+        "entities": "^4.5.0",
+        "find-up-simple": "^1.0.1",
+        "globals": "^17.7.0",
+        "indent-string": "^5.0.0",
+        "is-builtin-module": "^5.0.0",
+        "is-identifier": "^1.1.0",
+        "pluralize": "^8.0.0",
+        "quote-js-string": "^0.1.0",
+        "regjsparser": "^0.13.2",
+        "reserved-identifiers": "^1.2.0",
+        "semver": "^7.8.5",
+        "strip-indent": "^4.1.1",
+        "yaml": "^2.9.0"
+      },
+      "engines": {
+        "node": ">=22"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/eslint-plugin-unicorn?sponsor=1"
+      },
+      "peerDependencies": {
+        "eslint": ">=10.4"
+      }
+    },
+    "node_modules/eslint-plugin-unicorn/node_modules/indent-string": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-5.0.0.tgz",
+      "integrity": "sha512-m6FAo/spmsW2Ab2fU35JTYwtOKa2yAwXSwgjSv1TJzh4Mh7mC3lzAOVLBprb72XsTrgkEIsl7YrFNAiDiRhIGg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/eslint-plugin-unicorn/node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/eslint-plugin-unicorn/node_modules/strip-indent": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-4.1.1.tgz",
+      "integrity": "sha512-SlyRoSkdh1dYP0PzclLE7r0M9sgbFKKMFXpFRUMNuKhQSbC6VQIGzq3E0qsfvGJaUFJPGv6Ws1NZ/haTAjfbMA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/eslint-scope": {
@@ -7455,6 +7720,19 @@
         "node": ">=8"
       }
     },
+    "node_modules/find-up-simple": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/find-up-simple/-/find-up-simple-1.0.1.tgz",
+      "integrity": "sha512-afd4O7zpqHeRyg4PfDQsXmlDe2PfdHtJt6Akt8jOWaApLOZk5JXs6VMR29lz03pRe9mpykrRCYIYxaJYcfpncQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/flat-cache": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-4.0.1.tgz",
@@ -7567,6 +7845,26 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/function-timeout": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/function-timeout/-/function-timeout-1.0.2.tgz",
+      "integrity": "sha512-939eZS4gJ3htTHAldmyyuzlrD58P03fHG49v2JfFXbV6OhvZKRC9j2yAtdHw/zrp2zXHuv05zMIy40F0ge7spA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/functional-red-black-tree": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
+      "integrity": "sha512-dsKNQNdj6xA3T+QlADDA7mOSlX0qiMINjn0cgr+eGHGsbSHzTabcIogz2+p/iqP1Xs6EP/sS2SbqH+brGTbq0g==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/gensync": {
       "version": "1.0.0-beta.2",
       "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
@@ -7657,6 +7955,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/get-tsconfig": {
+      "version": "4.14.0",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.14.0.tgz",
+      "integrity": "sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "resolve-pkg-maps": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
       }
     },
     "node_modules/glob": {
@@ -7842,6 +8153,13 @@
       "integrity": "sha512-xYfnw62CKG8nLkZBfWbhWwDw02CHty86jfPcc2cr3ZfeuK9ysoVPPEUxf21bAD/rWAgk52SuBrLJlefNy8mvFg==",
       "dev": true
     },
+    "node_modules/globrex": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/globrex/-/globrex-0.1.2.tgz",
+      "integrity": "sha512-uHJgbwAMwNFf5mLst7IWLNg14x1CkeqglJb/K3doi4dw6q2IvAAmM/Y81kevy83wP+Sst+nutFTYOGg3d1lsxg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/gopd": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
@@ -7945,6 +8263,29 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/hosted-git-info": {
+      "version": "6.1.3",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-6.1.3.tgz",
+      "integrity": "sha512-HVJyzUrLIL1c0QmviVh5E8VGyUS7xCFPS6yydaVd1UegW+ibV/CohqTH9MkOLDp5o+rb82DMo77PTuc9F/8GKw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "lru-cache": "^7.5.1"
+      },
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
+    "node_modules/hosted-git-info/node_modules/lru-cache": {
+      "version": "7.18.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.18.3.tgz",
+      "integrity": "sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/html-encoding-sniffer": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-3.0.0.tgz",
@@ -7956,6 +8297,23 @@
       "engines": {
         "node": ">=12"
       }
+    },
+    "node_modules/html-entities": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/html-entities/-/html-entities-2.6.0.tgz",
+      "integrity": "sha512-kig+rMn/QOVRvr7c86gQ8lWXq+Hkv6CbAH1hLu+RG338StTpE8Z0b44SDVaqVu7HGKf27frdmUYEs9hTUX/cLQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/mdevils"
+        },
+        {
+          "type": "patreon",
+          "url": "https://patreon.com/mdevils"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/html-escaper": {
       "version": "2.0.2",
@@ -8080,6 +8438,22 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/identifier-regex": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/identifier-regex/-/identifier-regex-1.1.0.tgz",
+      "integrity": "sha512-SLX4H/vtcYlYnL7XqnuJKHU7Z8517TgsW9nmQiGOgMCjQ8V/deLYu6bEmbGoXe7WMMhc9+EUGyFFneHja8KabA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "reserved-identifiers": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/ignore": {
@@ -8234,6 +8608,35 @@
         "node": ">=8"
       }
     },
+    "node_modules/is-builtin-module": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-5.0.0.tgz",
+      "integrity": "sha512-f4RqJKBUe5rQkJ2eJEJBXSticB3hGbN9j0yxxMQFqIW89Jp9WYFtzfTcRlstDKVUTRzSOTLKRfO9vIztenwtxA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "builtin-modules": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18.20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-builtin-module/node_modules/builtin-modules": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-5.3.0.tgz",
+      "integrity": "sha512-hMQUl2bUFG339QygPM97E+mc8OY1IAchORZxm4a/frcYwKzozMzRVDBwHW0NjOqGElLm2O37AVQE8ikxlZHrMQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/is-core-module": {
       "version": "2.16.1",
       "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.1.tgz",
@@ -8309,6 +8712,23 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/is-identifier": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-identifier/-/is-identifier-1.1.0.tgz",
+      "integrity": "sha512-NhOds0mDx9lJu+1lBRO0xbwFo5nobA7GCk/0e5xjr6+6XugX985+0OyGX35BNrTkPAsdLcIKg02HUQJOK8D8kw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "identifier-regex": "^1.1.0",
+        "super-regex": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/is-module": {
@@ -9465,9 +9885,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -9482,9 +9899,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -9499,9 +9913,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -9619,6 +10030,16 @@
         "@75lb/nature": {
           "optional": true
         }
+      }
+    },
+    "node_modules/jsdoc-type-pratt-parser": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/jsdoc-type-pratt-parser/-/jsdoc-type-pratt-parser-7.2.0.tgz",
+      "integrity": "sha512-dh140MMgjyg3JhJZY/+iEzW+NO5xR2gpbDFKHqotCmexElVntw7GjWjt511+C/Ef02RU5TKYrJo/Xlzk+OLaTw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.0.0"
       }
     },
     "node_modules/jsdoc/node_modules/escape-string-regexp": {
@@ -9773,6 +10194,16 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/jsx-ast-utils-x": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/jsx-ast-utils-x/-/jsx-ast-utils-x-0.1.0.tgz",
+      "integrity": "sha512-eQQBjBnsVtGacsG9uJNB8qOr3yA8rga4wAaGG1qRcBzSIvfhERLrWxMAM1hp5fcS6Abo8M4+bUBTekYR0qTPQw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
     "node_modules/katex": {
       "version": "0.16.47",
       "resolved": "https://registry.npmjs.org/katex/-/katex-0.16.47.tgz",
@@ -9848,6 +10279,57 @@
       },
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/license-checker-rseidelsohn": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/license-checker-rseidelsohn/-/license-checker-rseidelsohn-4.4.2.tgz",
+      "integrity": "sha512-Sf8WaJhd2vELvCne+frS9AXqnY/vv591s2/nZcJDwTnoNgltG4mAmoenffVb8L2YPRYbxARLyrHJBC38AVfpuA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "chalk": "4.1.2",
+        "debug": "^4.3.4",
+        "lodash.clonedeep": "^4.5.0",
+        "mkdirp": "^1.0.4",
+        "nopt": "^7.2.0",
+        "read-installed-packages": "^2.0.1",
+        "semver": "^7.3.5",
+        "spdx-correct": "^3.1.1",
+        "spdx-expression-parse": "^3.0.1",
+        "spdx-satisfies": "^5.0.1",
+        "treeify": "^1.1.0"
+      },
+      "bin": {
+        "license-checker-rseidelsohn": "bin/license-checker-rseidelsohn.js"
+      },
+      "engines": {
+        "node": ">=18",
+        "npm": ">=8"
+      }
+    },
+    "node_modules/license-checker-rseidelsohn/node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/license-checker-rseidelsohn/node_modules/spdx-expression-parse": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.1.tgz",
+      "integrity": "sha512-cbqHunsQWnJNE6KhVSMsMeH5H/L9EpymbzqTQ3uLwNCLZ1Q481oWaofqH7nO6V07xlXwY6PhQdQ2IedWx/ZK4Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "spdx-exceptions": "^2.1.0",
+        "spdx-license-ids": "^3.0.0"
       }
     },
     "node_modules/lilconfig": {
@@ -9937,11 +10419,25 @@
       "integrity": "sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==",
       "dev": true
     },
+    "node_modules/lodash.clonedeep": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
+      "integrity": "sha512-H5ZhCF25riFd9uB5UCkVKo61m3S/xZk1x4wA6yp/L3RFP6Z/eHH1ymQcGLo7J3GMPfm0V/7m1tryHuGVxpqEBQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/lodash.debounce": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
       "integrity": "sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow==",
       "dev": true
+    },
+    "node_modules/lodash.merge": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
+      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/lodash.truncate": {
       "version": "4.4.2",
@@ -9974,6 +10470,37 @@
       "dev": true,
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/make-asynchronous": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/make-asynchronous/-/make-asynchronous-1.1.0.tgz",
+      "integrity": "sha512-ayF7iT+44LXdxJLTrTd3TLQpFDDvPCBxXxbv+pMUSuHA5Q8zyAfwkRP6aHHwNVFBUFWtxAHqwNJxF8vMZLAbVg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-event": "^6.0.0",
+        "type-fest": "^4.6.0",
+        "web-worker": "^1.5.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/make-asynchronous/node_modules/type-fest": {
+      "version": "4.41.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
+      "integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==",
+      "dev": true,
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/make-dir": {
@@ -10987,6 +11514,51 @@
         "node": ">=18"
       }
     },
+    "node_modules/nopt": {
+      "version": "7.2.1",
+      "resolved": "https://registry.npmjs.org/nopt/-/nopt-7.2.1.tgz",
+      "integrity": "sha512-taM24ViiimT/XntxbPyJQzCG+p4EKOpgD3mxFwW38mGjVUrfERQOeY4EDHjdnptttfHuHQXFx+lTP08Q+mLa/w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "abbrev": "^2.0.0"
+      },
+      "bin": {
+        "nopt": "bin/nopt.js"
+      },
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
+    "node_modules/normalize-package-data": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-5.0.0.tgz",
+      "integrity": "sha512-h9iPVIfrVZ9wVYQnxFgtw1ugSvGEMOlyPWWtm8BMJhnwyEL/FLbYbTY3V3PpjI/BUK67n9PEWDu6eHzu1fB15Q==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "hosted-git-info": "^6.0.0",
+        "is-core-module": "^2.8.1",
+        "semver": "^7.3.5",
+        "validate-npm-package-license": "^3.0.4"
+      },
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
+    "node_modules/normalize-package-data/node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/normalize-path": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
@@ -10994,6 +11566,16 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/npm-normalize-package-bin": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/npm-normalize-package-bin/-/npm-normalize-package-bin-3.0.1.tgz",
+      "integrity": "sha512-dMxCf+zZ+3zeQZXKxmyuCKlIDPGuv8EF940xbkC4kQVDTtqoh6rJFO+JTKSA6/Rwi0getWmtuy4Itup0AMcaDQ==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
     },
     "node_modules/npm-run-path": {
@@ -11013,6 +11595,13 @@
       "version": "2.2.24",
       "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.24.tgz",
       "integrity": "sha512-7YRhZ3jS45LwmSCT4b2sVFHt/WuovaktDU07QrtOBY2PXskss5a9jfmR9jptyumwXST+rFjrmppMY1KT/yn35A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/object-deep-merge": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/object-deep-merge/-/object-deep-merge-2.0.1.tgz",
+      "integrity": "sha512-aKttDKcU3pyZqKcCkDhsMn70WmZFG2JGDQLP9EcLyTSIFQRCPWLAmBZRLJnrVUrhPG1jETEEbfdgbNtJf1LyMg==",
       "dev": true,
       "license": "MIT"
     },
@@ -11089,6 +11678,22 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/p-event": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/p-event/-/p-event-6.0.1.tgz",
+      "integrity": "sha512-Q6Bekk5wpzW5qIyUP4gdMEujObYstZl6DMMOSenwBvV0BlE5LkDwkjs5yHbZmdCEq2o4RJx4tE1vwxFVf2FG1w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-timeout": "^6.1.2"
+      },
+      "engines": {
+        "node": ">=16.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/p-limit": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
@@ -11126,6 +11731,19 @@
       },
       "engines": {
         "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-timeout": {
+      "version": "6.1.4",
+      "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-6.1.4.tgz",
+      "integrity": "sha512-MyIV3ZA/PmyBN/ud8vV9XzwTrNtR4jFrObymZYnZqMmW0zA8Z17vnT0rBgFE/TlohB+YCHqXMgZzb3Csp49vqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.16"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -11179,6 +11797,16 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/parse-imports-exports": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/parse-imports-exports/-/parse-imports-exports-0.2.4.tgz",
+      "integrity": "sha512-4s6vd6dx1AotCx/RCI2m7t7GCh5bDRUtGNvRfHSP2wbBQdMi67pPe7mtzmgwcaQ8VKK/6IB7Glfyu3qdZJPybQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "parse-statements": "1.0.11"
+      }
+    },
     "node_modules/parse-json": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
@@ -11197,6 +11825,13 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/parse-statements": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/parse-statements/-/parse-statements-1.0.11.tgz",
+      "integrity": "sha512-HlsyYdMBnbPQ9Jr/VgJ1YF4scnldvJpJxCVx6KgqPL4dxppsWrJHCIIxQXMJrqGnsRkNPATbeMJ8Yxu7JMsYcA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/parse5": {
       "version": "7.3.0",
@@ -11393,6 +12028,16 @@
       ],
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/pluralize": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-8.0.0.tgz",
+      "integrity": "sha512-Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/portfinder": {
@@ -11960,6 +12605,19 @@
         }
       ]
     },
+    "node_modules/quote-js-string": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/quote-js-string/-/quote-js-string-0.1.0.tgz",
+      "integrity": "sha512-Y3NoRtprEEZQD8RfxMCfS0ZTqc4e+i18OrXEXAvpM6TfC/3y+0L5rNbZiSnbBBEkDfFzbpd8o+cE8q3/anjMGA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=22"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/quote-js-string?sponsor=1"
+      }
+    },
     "node_modules/react-is": {
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
@@ -11989,6 +12647,53 @@
       "dev": true,
       "dependencies": {
         "pify": "^2.3.0"
+      }
+    },
+    "node_modules/read-installed-packages": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/read-installed-packages/-/read-installed-packages-2.0.1.tgz",
+      "integrity": "sha512-t+fJOFOYaZIjBpTVxiV8Mkt7yQyy4E6MSrrnt5FmPd4enYvpU/9DYGirDmN1XQwkfeuWIhM/iu0t2rm6iSr0CA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "@npmcli/fs": "^3.1.0",
+        "debug": "^4.3.4",
+        "read-package-json": "^6.0.0",
+        "semver": "2 || 3 || 4 || 5 || 6 || 7",
+        "slide": "~1.1.3"
+      },
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.2"
+      }
+    },
+    "node_modules/read-package-json": {
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/read-package-json/-/read-package-json-6.0.4.tgz",
+      "integrity": "sha512-AEtWXYfopBj2z5N5PbkAOeNHRPUg5q+Nen7QLxV8M2zJq1ym6/lCz3fYNTCXe19puu2d06jfHhrP7v/S2PtMMw==",
+      "deprecated": "This package is no longer supported. Please use @npmcli/package-json instead.",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "glob": "^10.2.2",
+        "json-parse-even-better-errors": "^3.0.0",
+        "normalize-package-data": "^5.0.0",
+        "npm-normalize-package-bin": "^3.0.0"
+      },
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
+    "node_modules/read-package-json/node_modules/json-parse-even-better-errors": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-3.0.2.tgz",
+      "integrity": "sha512-fi0NG4bPjCHunUJffmLd0gxssIgkNmArMvis4iNah6Owg1MCJjWhEcDLmsK6iGkJq3tHwbDkTlce70/tmXN4cQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
     },
     "node_modules/readdirp": {
@@ -12028,6 +12733,19 @@
         "node": ">=8"
       }
     },
+    "node_modules/refa": {
+      "version": "0.12.1",
+      "resolved": "https://registry.npmjs.org/refa/-/refa-0.12.1.tgz",
+      "integrity": "sha512-J8rn6v4DBb2nnFqkqwy6/NnTYMcgLA+sLr0iIO41qpv0n+ngb7ksag2tMRl0inb1bbO/esUwzW1vbJi7K0sI0g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/regexpp": "^4.8.0"
+      },
+      "engines": {
+        "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
+      }
+    },
     "node_modules/regenerate": {
       "version": "1.4.2",
       "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.4.2.tgz",
@@ -12044,6 +12762,30 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/regexp-ast-analysis": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/regexp-ast-analysis/-/regexp-ast-analysis-0.7.1.tgz",
+      "integrity": "sha512-sZuz1dYW/ZsfG17WSAG7eS85r5a0dDsvg+7BiiYR5o6lKCAtUrEwdmRmaGF6rwVj3LcmAeYkOWKEPlbPzN3Y3A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/regexpp": "^4.8.0",
+        "refa": "^0.12.1"
+      },
+      "engines": {
+        "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
+      }
+    },
+    "node_modules/regexp-tree": {
+      "version": "0.1.27",
+      "resolved": "https://registry.npmjs.org/regexp-tree/-/regexp-tree-0.1.27.tgz",
+      "integrity": "sha512-iETxpjK6YoRWJG5o6hXLwvjYAoW+FEZn9os0PD/b6AP6xQwsa/Y7lCVgIixBbUPMfhu+i2LtdeAqVTgGlQarfA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "regexp-tree": "bin/regexp-tree"
       }
     },
     "node_modules/regexpu-core": {
@@ -12070,10 +12812,11 @@
       "dev": true
     },
     "node_modules/regjsparser": {
-      "version": "0.13.1",
-      "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.13.1.tgz",
-      "integrity": "sha512-dLsljMd9sqwRkby8zhO1gSg3PnJIBFid8f4CQj/sXx+7cKx+E7u0PKhZ+U4wmhx7EfmtvnA318oVaIkAB1lRJw==",
+      "version": "0.13.2",
+      "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.13.2.tgz",
+      "integrity": "sha512-NgRBy2Nx/bE+9F27nVHnqcN5HjyLmecqsqx2PJHu3/IEtADD4WuxuXIVExD5PoSDFVrl78dOonfcOe5O+5nbzQ==",
       "dev": true,
+      "license": "BSD-2-Clause",
       "dependencies": {
         "jsesc": "~3.1.0"
       },
@@ -12112,6 +12855,19 @@
       "dev": true,
       "dependencies": {
         "lodash": "^4.17.21"
+      }
+    },
+    "node_modules/reserved-identifiers": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/reserved-identifiers/-/reserved-identifiers-1.2.0.tgz",
+      "integrity": "sha512-yE7KUfFvaBFzGPs5H3Ops1RevfUEsDc5Iz65rOwWg4lE8HJSYtle77uul3+573457oHvBKuHYDl/xqUkKpEEdw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/resolve": {
@@ -12155,6 +12911,16 @@
       "dev": true,
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/resolve-pkg-maps": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
+      "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
       }
     },
     "node_modules/reusify": {
@@ -12429,6 +13195,16 @@
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
       "dev": true
     },
+    "node_modules/safe-regex": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-2.1.1.tgz",
+      "integrity": "sha512-rx+x8AMzKb5Q5lQ95Zoi6ZbJqwCLkqi3XuJXp5P3rT8OEc6sZCJG5AE5dU3lsgRr/F4Bs31jSlVN+j5KrsGu9A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "regexp-tree": "~0.1.1"
+      }
+    },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
@@ -12446,6 +13222,21 @@
       },
       "engines": {
         "node": ">=v12.22.7"
+      }
+    },
+    "node_modules/scslre": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/scslre/-/scslre-0.3.0.tgz",
+      "integrity": "sha512-3A6sD0WYP7+QrjbfNA2FN3FsOaGGFoekCVgTyypy53gPxhbkCIjtO6YWgdrfM+n/8sI8JeXZOIxsHjMTNxQ4nQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/regexpp": "^4.8.0",
+        "refa": "^0.12.0",
+        "regexp-ast-analysis": "^0.7.0"
+      },
+      "engines": {
+        "node": "^14.0.0 || >=16.0.0"
       }
     },
     "node_modules/secure-compare": {
@@ -12648,6 +13439,16 @@
         "url": "https://github.com/chalk/slice-ansi?sponsor=1"
       }
     },
+    "node_modules/slide": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/slide/-/slide-1.1.6.tgz",
+      "integrity": "sha512-NwrtjCg+lZoqhFU8fOwl4ay2ei8PaqCBOUV3/ektPY9trO1yQ1oXEfmHAhKArUVUr/hOHvy5f6AdP17dCM0zMw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/smob": {
       "version": "1.6.1",
       "resolved": "https://registry.npmjs.org/smob/-/smob-1.6.1.tgz",
@@ -12720,11 +13521,121 @@
         "source-map": "^0.6.0"
       }
     },
+    "node_modules/spdx-compare": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/spdx-compare/-/spdx-compare-1.0.0.tgz",
+      "integrity": "sha512-C1mDZOX0hnu0ep9dfmuoi03+eOdDoz2yvK79RxbcrVEG1NO1Ph35yW102DHWKN4pk80nwCgeMmSY5L25VE4D9A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "array-find-index": "^1.0.2",
+        "spdx-expression-parse": "^3.0.0",
+        "spdx-ranges": "^2.0.0"
+      }
+    },
+    "node_modules/spdx-compare/node_modules/spdx-expression-parse": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.1.tgz",
+      "integrity": "sha512-cbqHunsQWnJNE6KhVSMsMeH5H/L9EpymbzqTQ3uLwNCLZ1Q481oWaofqH7nO6V07xlXwY6PhQdQ2IedWx/ZK4Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "spdx-exceptions": "^2.1.0",
+        "spdx-license-ids": "^3.0.0"
+      }
+    },
+    "node_modules/spdx-correct": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.2.0.tgz",
+      "integrity": "sha512-kN9dJbvnySHULIluDHy32WHRUu3Og7B9sbY7tsFLctQkIqnMh3hErYgdMjTYuqmcXX+lK5T1lnUt3G7zNswmZA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "spdx-expression-parse": "^3.0.0",
+        "spdx-license-ids": "^3.0.0"
+      }
+    },
+    "node_modules/spdx-correct/node_modules/spdx-expression-parse": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.1.tgz",
+      "integrity": "sha512-cbqHunsQWnJNE6KhVSMsMeH5H/L9EpymbzqTQ3uLwNCLZ1Q481oWaofqH7nO6V07xlXwY6PhQdQ2IedWx/ZK4Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "spdx-exceptions": "^2.1.0",
+        "spdx-license-ids": "^3.0.0"
+      }
+    },
+    "node_modules/spdx-exceptions": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.5.0.tgz",
+      "integrity": "sha512-PiU42r+xO4UbUS1buo3LPJkjlO7430Xn5SVAhdpzzsPHsjbYVflnnFdATgabnLude+Cqu25p6N+g2lw/PFsa4w==",
+      "dev": true,
+      "license": "CC-BY-3.0"
+    },
+    "node_modules/spdx-expression-parse": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-4.0.0.tgz",
+      "integrity": "sha512-Clya5JIij/7C6bRR22+tnGXbc4VKlibKSVj2iHvVeX5iMW7s1SIQlqu699JkODJJIhh/pUu8L0/VLh8xflD+LQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "spdx-exceptions": "^2.1.0",
+        "spdx-license-ids": "^3.0.0"
+      }
+    },
+    "node_modules/spdx-license-ids": {
+      "version": "3.0.23",
+      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.23.tgz",
+      "integrity": "sha512-CWLcCCH7VLu13TgOH+r8p1O/Znwhqv/dbb6lqWy67G+pT1kHmeD/+V36AVb/vq8QMIQwVShJ6Ssl5FPh0fuSdw==",
+      "dev": true,
+      "license": "CC0-1.0"
+    },
+    "node_modules/spdx-ranges": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/spdx-ranges/-/spdx-ranges-2.1.1.tgz",
+      "integrity": "sha512-mcdpQFV7UDAgLpXEE/jOMqvK4LBoO0uTQg0uvXUewmEFhpiZx5yJSZITHB8w1ZahKdhfZqP5GPEOKLyEq5p8XA==",
+      "dev": true,
+      "license": "(MIT AND CC-BY-3.0)"
+    },
+    "node_modules/spdx-satisfies": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/spdx-satisfies/-/spdx-satisfies-5.0.1.tgz",
+      "integrity": "sha512-Nwor6W6gzFp8XX4neaKQ7ChV4wmpSh2sSDemMFSzHxpTw460jxFYeOn+jq4ybnSSw/5sc3pjka9MQPouksQNpw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "spdx-compare": "^1.0.0",
+        "spdx-expression-parse": "^3.0.0",
+        "spdx-ranges": "^2.0.0"
+      }
+    },
+    "node_modules/spdx-satisfies/node_modules/spdx-expression-parse": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.1.tgz",
+      "integrity": "sha512-cbqHunsQWnJNE6KhVSMsMeH5H/L9EpymbzqTQ3uLwNCLZ1Q481oWaofqH7nO6V07xlXwY6PhQdQ2IedWx/ZK4Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "spdx-exceptions": "^2.1.0",
+        "spdx-license-ids": "^3.0.0"
+      }
+    },
     "node_modules/sprintf-js": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
       "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
       "dev": true
+    },
+    "node_modules/stable-hash-x": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/stable-hash-x/-/stable-hash-x-0.2.0.tgz",
+      "integrity": "sha512-o3yWv49B/o4QZk5ZcsALc6t0+eCelPc44zZsLtCQnZPDwFpDYSWcDnrv2TtMmMbQ7uKo3J0HTURCqckw23czNQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      }
     },
     "node_modules/stack-utils": {
       "version": "2.0.6",
@@ -13264,6 +14175,24 @@
         "postcss": "^8.3.3"
       }
     },
+    "node_modules/super-regex": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/super-regex/-/super-regex-1.1.0.tgz",
+      "integrity": "sha512-WHkws2ZflZe41zj6AolvvmaTrWds/VuyeYr9iPVv/oQeaIoVxMKaushfFWpOGDT+GuBrM/sVqF8KUCYQlSSTdQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "function-timeout": "^1.0.1",
+        "make-asynchronous": "^1.0.1",
+        "time-span": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/supports-color": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -13421,6 +14350,20 @@
         "node": ">=8"
       }
     },
+    "node_modules/tapable": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.3.3.tgz",
+      "integrity": "sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      }
+    },
     "node_modules/terser": {
       "version": "5.46.1",
       "resolved": "https://registry.npmjs.org/terser/-/terser-5.46.1.tgz",
@@ -13496,6 +14439,22 @@
       "integrity": "sha512-D+BkEl5MpeTbQ1Rz0io/TLZmwmYUAgvUpS1r2eKUvPicYOnpqzjZE6bVa7rSEYv189zkSM+CVc+hG5X7nVe9LQ==",
       "dev": true
     },
+    "node_modules/time-span": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/time-span/-/time-span-5.1.0.tgz",
+      "integrity": "sha512-75voc/9G4rDIJleOo4jPvN4/YC4GRZrY8yy1uU4lwrB3XEQbWve8zXoO5No4eFrGcTAMYyoY67p8jRQdtA1HbA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "convert-hrtime": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/tinyexec": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.2.4.tgz",
@@ -13562,6 +14521,23 @@
         "node": ">=8.0"
       }
     },
+    "node_modules/to-valid-identifier": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/to-valid-identifier/-/to-valid-identifier-1.0.0.tgz",
+      "integrity": "sha512-41wJyvKep3yT2tyPqX/4blcfybknGB4D+oETKLs7Q76UiPqRpUJK3hr1nxelyYO0PHKVzJwlu0aCeEAsGI6rpw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@sindresorhus/base62": "^1.0.0",
+        "reserved-identifiers": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/totalist": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/totalist/-/totalist-3.0.1.tgz",
@@ -13595,6 +14571,29 @@
       },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/treeify": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/treeify/-/treeify-1.1.0.tgz",
+      "integrity": "sha512-1m4RA7xVAJrSGrrXGs0L3YTwyvBs2S8PbRHaLZAkFw7JR8oIFwYtysxlBZhYIa7xSyiYJKZ3iGrrk55cGA3i9A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/ts-api-utils": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.5.0.tgz",
+      "integrity": "sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.12"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4"
       }
     },
     "node_modules/tslib": {
@@ -13641,39 +14640,17 @@
       }
     },
     "node_modules/typescript": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-7.0.2.tgz",
-      "integrity": "sha512-8FYau96o3NKOhbjKi/qNvG/W5jhzxkbdm5sj9AbZ/5T5sWqn3hJgLfGx27sRKZWTvyzCP8dLRBTf5tBTSRVUNA==",
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
-        "tsc": "bin/tsc"
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
       },
       "engines": {
-        "node": ">=16.20.0"
-      },
-      "optionalDependencies": {
-        "@typescript/typescript-aix-ppc64": "7.0.2",
-        "@typescript/typescript-darwin-arm64": "7.0.2",
-        "@typescript/typescript-darwin-x64": "7.0.2",
-        "@typescript/typescript-freebsd-arm64": "7.0.2",
-        "@typescript/typescript-freebsd-x64": "7.0.2",
-        "@typescript/typescript-linux-arm": "7.0.2",
-        "@typescript/typescript-linux-arm64": "7.0.2",
-        "@typescript/typescript-linux-loong64": "7.0.2",
-        "@typescript/typescript-linux-mips64el": "7.0.2",
-        "@typescript/typescript-linux-ppc64": "7.0.2",
-        "@typescript/typescript-linux-riscv64": "7.0.2",
-        "@typescript/typescript-linux-s390x": "7.0.2",
-        "@typescript/typescript-linux-x64": "7.0.2",
-        "@typescript/typescript-netbsd-arm64": "7.0.2",
-        "@typescript/typescript-netbsd-x64": "7.0.2",
-        "@typescript/typescript-openbsd-arm64": "7.0.2",
-        "@typescript/typescript-openbsd-x64": "7.0.2",
-        "@typescript/typescript-sunos-x64": "7.0.2",
-        "@typescript/typescript-win32-arm64": "7.0.2",
-        "@typescript/typescript-win32-x64": "7.0.2"
+        "node": ">=14.17"
       }
     },
     "node_modules/typical": {
@@ -13895,6 +14872,28 @@
         "node": ">=10.12.0"
       }
     },
+    "node_modules/validate-npm-package-license": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
+      "integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "spdx-correct": "^3.0.0",
+        "spdx-expression-parse": "^3.0.0"
+      }
+    },
+    "node_modules/validate-npm-package-license/node_modules/spdx-expression-parse": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.1.tgz",
+      "integrity": "sha512-cbqHunsQWnJNE6KhVSMsMeH5H/L9EpymbzqTQ3uLwNCLZ1Q481oWaofqH7nO6V07xlXwY6PhQdQ2IedWx/ZK4Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "spdx-exceptions": "^2.1.0",
+        "spdx-license-ids": "^3.0.0"
+      }
+    },
     "node_modules/w3c-xmlserializer": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
@@ -13944,6 +14943,13 @@
       "dependencies": {
         "makeerror": "1.0.12"
       }
+    },
+    "node_modules/web-worker": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/web-worker/-/web-worker-1.5.0.tgz",
+      "integrity": "sha512-RiMReJrTAiA+mBjGONMnjVDP2u3p9R1vkcGz6gDIrOMT3oGuYwX2WRMYI9ipkphSuE5XKEhydbhNEJh4NY9mlw==",
+      "dev": true,
+      "license": "Apache-2.0"
     },
     "node_modules/webidl-conversions": {
       "version": "7.0.0",

--- a/package.json
+++ b/package.json
@@ -54,7 +54,10 @@
     "lint:cpd": "jscpd . --config .jscpd.json",
     "lint:cpd:ci": "jscpd . --config .jscpd.json --threshold 5",
     "security:audit": "npm audit",
-    "security:check": "npm audit --audit-level=high"
+    "security:check": "npm audit --audit-level=high",
+    "lint:licenses": "license-checker-rseidelsohn --production --excludePrivatePackages --onlyAllow 'MIT;ISC;BSD-2-Clause;BSD-3-Clause;Apache-2.0;CC0-1.0;Unlicense;0BSD;BlueOak-1.0.0;CC-BY-4.0;Python-2.0'",
+    "check:all": "npm run check && npm run lint:cpd:ci && npm run lint:licenses && npm test",
+    "bootstrap": "bash scripts/bootstrap.sh"
   },
   "keywords": [
     "accessibility",
@@ -104,6 +107,14 @@
     "babel-jest": "^30.4.1",
     "commit-and-tag-version": "^13.1.0",
     "eslint": "^10.7.0",
+    "eslint-plugin-import-x": "^4.17.1",
+    "eslint-plugin-jsdoc": "^63.2.0",
+    "eslint-plugin-n": "^18.2.2",
+    "eslint-plugin-no-secrets": "^2.3.3",
+    "eslint-plugin-promise": "^7.3.0",
+    "eslint-plugin-security": "^4.0.1",
+    "eslint-plugin-sonarjs": "^4.2.0",
+    "eslint-plugin-unicorn": "^72.0.0",
     "globals": "^17.7.0",
     "http-server": "^14.1.1",
     "husky": "^9.1.7",
@@ -112,6 +123,7 @@
     "jscpd": "^5.0.12",
     "jsdoc": "^4.0.5",
     "jsdoc-to-markdown": "^9.1.3",
+    "license-checker-rseidelsohn": "^4.4.2",
     "lint-staged": "17.1.1",
     "markdownlint-cli": "^0.49.1",
     "playwright": "^1.61.1",
@@ -130,6 +142,7 @@
     "size-limit": "^12.1.0",
     "stylelint": "^17.14.1",
     "stylelint-config-standard": "^40.0.0",
+    "typescript": "~5.9.0",
     "webpack-bundle-analyzer": "^5.3.1"
   },
   "babel": {

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# Bootstrap optional external binaries used by local quality gates and
+# scheduled scans (see docs/adr/0001-tooling-stack-decisions.md and #62).
+# Everything installed here is optional: hooks skip tools that are absent.
+set -euo pipefail
+
+have() { command -v "$1" >/dev/null 2>&1; }
+
+install_with_brew() {
+  local pkg=$1
+  if have brew; then
+    echo "Installing $pkg via Homebrew..."
+    brew install "$pkg"
+  else
+    echo "SKIP: $pkg — install manually (no Homebrew found)." >&2
+  fi
+}
+
+echo "== cookie-banner tooling bootstrap =="
+
+# Node version per .nvmrc
+if have nvm || [ -s "${NVM_DIR:-$HOME/.nvm}/nvm.sh" ]; then
+  echo "Run 'nvm use' to match the pinned Node version ($(cat .nvmrc))."
+elif ! node --version | grep -q "^v$(cat .nvmrc)\."; then
+  echo "WARN: node $(node --version) does not match .nvmrc ($(cat .nvmrc))." >&2
+fi
+
+# Secret scanning (pre-commit uses it when present)
+have gitleaks || install_with_brew gitleaks
+
+# Static analysis with OWASP rulesets (scheduled/manual)
+have semgrep || install_with_brew semgrep
+
+# Dependency vulnerability scanning against the OSV database
+have osv-scanner || install_with_brew osv-scanner
+
+# Markdown link rot checking (weekly Action; optional locally)
+have lychee || install_with_brew lychee
+
+echo "Done. Optional extras not installed by this script:"
+echo "  - CodeQL CLI (heavy; CI runs it on schedule)"
+echo "  - OWASP Dependency-Check (Java; CI runs it on schedule)"

--- a/src/js/banner-dom.js
+++ b/src/js/banner-dom.js
@@ -1,5 +1,5 @@
 /**
- * @fileoverview DOM construction for the cookie banner and preferences modal.
+ * @file DOM construction for the cookie banner and preferences modal.
  * Builders receive configuration and locale strings and return detached
  * elements; the caller owns insertion into the document. Extracted from
  * banner.js (see AFixt/cookie-banner#69).
@@ -37,8 +37,8 @@ function buildBannerButton(id, action, label) {
 
 /**
  * Create the cookie banner element (detached)
- * @param {Object} config - Banner configuration
- * @param {Object} strings - Locale strings
+ * @param {object} config - Banner configuration
+ * @param {object} strings - Locale strings
  * @returns {HTMLDivElement} The banner element
  */
 export function createBannerElement(config, strings) {
@@ -77,7 +77,7 @@ export function createBannerElement(config, strings) {
 /**
  * Create one cookie-category row: a labelled checkbox with optional
  * description paragraph.
- * @param {Object} options - Category options
+ * @param {object} options - Category options
  * @param {string} options.name - Checkbox name attribute
  * @param {boolean} options.checked - Initial checked state
  * @param {boolean} options.disabled - Whether the checkbox is locked
@@ -114,8 +114,8 @@ function buildCategoryRow({ name, checked, disabled, label, description }) {
 
 /**
  * Create the fieldset grouping all cookie-category checkboxes
- * @param {Object} config - Banner configuration
- * @param {Object} strings - Locale strings
+ * @param {object} config - Banner configuration
+ * @param {object} strings - Locale strings
  * @returns {HTMLFieldSetElement}
  */
 function buildCategoryFieldset(config, strings) {
@@ -157,7 +157,7 @@ function buildCategoryFieldset(config, strings) {
 
 /**
  * Create the modal action buttons (save / cancel)
- * @param {Object} strings - Locale strings
+ * @param {object} strings - Locale strings
  * @returns {HTMLDivElement}
  */
 function buildModalActions(strings) {
@@ -183,8 +183,8 @@ function buildModalActions(strings) {
 
 /**
  * Create the preferences modal element (detached, hidden)
- * @param {Object} config - Banner configuration
- * @param {Object} strings - Locale strings
+ * @param {object} config - Banner configuration
+ * @param {object} strings - Locale strings
  * @returns {HTMLDivElement} The modal element
  */
 export function createModalElement(config, strings) {

--- a/src/js/banner-focus.js
+++ b/src/js/banner-focus.js
@@ -1,5 +1,5 @@
 /**
- * @fileoverview Focus management for the preferences modal: capturing focus
+ * @file Focus management for the preferences modal: capturing focus
  * on open, trapping Tab/Shift+Tab inside the dialog, and restoring focus on
  * close (WCAG 2.2 focus management). Extracted from banner.js (see
  * AFixt/cookie-banner#69).
@@ -12,7 +12,7 @@ const FOCUSABLE_SELECTOR =
 /**
  * Create a focus manager for a modal dialog. Each manager instance owns the
  * focus bookkeeping that previously lived as module state in banner.js.
- * @returns {Object} Focus manager API
+ * @returns {object} Focus manager API
  */
 export function createFocusManager() {
   let firstFocusableElement = null;

--- a/src/js/banner-storage.js
+++ b/src/js/banner-storage.js
@@ -1,5 +1,5 @@
 /**
- * @fileoverview Consent storage helpers for the cookie banner — validation,
+ * @file Consent storage helpers for the cookie banner — validation,
  * secure cookie construction, and reading/writing consent from localStorage
  * or cookies. Extracted from banner.js (see AFixt/cookie-banner#69).
  * @module banner-storage
@@ -7,8 +7,8 @@
 
 /**
  * Validate a consent object against expected schema (M1)
- * @param {Object} obj - Object to validate
- * @returns {Object|null} Validated consent or null
+ * @param {object} obj - Object to validate
+ * @returns {object | null} Validated consent or null
  */
 export function validateConsentData(obj) {
   if (typeof obj !== 'object' || obj === null || Array.isArray(obj)) {
@@ -37,7 +37,7 @@ export function buildSecureCookie(name, value, expires) {
 /**
  * Read consent from the configured storage backend.
  * @param {string} storageMethod - 'localStorage' or 'cookie'
- * @returns {Object|null} Validated consent object or null
+ * @returns {object | null} Validated consent object or null
  */
 export function readStoredConsent(storageMethod) {
   try {
@@ -61,11 +61,11 @@ export function readStoredConsent(storageMethod) {
 /**
  * Persist consent to the configured storage backend. Functional cookies are
  * always forced on and a timestamp is stamped onto the stored value.
- * @param {Object} consent - Consent object with boolean values
- * @param {Object} options - Storage options
+ * @param {object} consent - Consent object with boolean values
+ * @param {object} options - Storage options
  * @param {string} options.storageMethod - 'localStorage' or 'cookie'
  * @param {number} options.expireDays - Cookie lifetime in days
- * @returns {Object} The consent object as stored (with timestamp)
+ * @returns {object} The consent object as stored (with timestamp)
  */
 export function writeStoredConsent(consent, { storageMethod, expireDays }) {
   const consentData = {

--- a/src/js/banner.js
+++ b/src/js/banner.js
@@ -1,5 +1,5 @@
 /**
- * @fileoverview Accessible Cookie Banner - Main functionality for banner and preference modal
+ * @file Accessible Cookie Banner - Main functionality for banner and preference modal
  * @module banner
  * @author Karl Groves <karlgroves@gmail.com>
  * @version 1.0.0
@@ -56,7 +56,7 @@ const _bannerAPI = (function () {
 
   /**
    * Initialize the cookie banner
-   * @param {Object} userConfig - Configuration options
+   * @param {object} userConfig - Configuration options
    */
   function initCookieBanner(userConfig = {}) {
     try {
@@ -79,7 +79,9 @@ const _bannerAPI = (function () {
         return Promise.resolve();
       }
 
-      // Load locale strings
+      // Load locale strings. The chain resolves with no value by contract;
+      // callers only await completion.
+      /* eslint-disable promise/always-return */
       return loadLocaleStrings(config.locale)
         .then(() => {
           try {
@@ -104,6 +106,7 @@ const _bannerAPI = (function () {
           console.error('Failed to initialize cookie banner:', error);
           throw error;
         });
+      /* eslint-enable promise/always-return */
     } catch (error) {
       console.error('Failed to initialize cookie banner:', error);
       throw error;
@@ -172,6 +175,8 @@ const _bannerAPI = (function () {
 
   /**
    * Add keyboard event handler to button
+   * @param button
+   * @param callback
    */
   function addKeyboardHandler(button, callback) {
     button.addEventListener('keydown', e => {
@@ -186,7 +191,7 @@ const _bannerAPI = (function () {
    * Route a consent decision through an external CookieConsent manager when
    * one is installed, otherwise store it directly. Shared by the accept,
    * reject, and save-preferences paths.
-   * @param {Object} consentData - Consent object with boolean values
+   * @param {object} consentData - Consent object with boolean values
    */
   function applyConsent(consentData) {
     if (window.CookieConsent && window.CookieConsent.setConsent !== setConsent) {
@@ -215,7 +220,7 @@ const _bannerAPI = (function () {
       }
     };
 
-    const acceptBtn = document.getElementById('accept-all');
+    const acceptBtn = document.querySelector('#accept-all');
     acceptBtn.addEventListener('click', acceptAllHandler);
     addKeyboardHandler(acceptBtn, acceptAllHandler);
 
@@ -229,12 +234,12 @@ const _bannerAPI = (function () {
       }
     };
 
-    const rejectBtn = document.getElementById('reject-all');
+    const rejectBtn = document.querySelector('#reject-all');
     rejectBtn.addEventListener('click', rejectAllHandler);
     addKeyboardHandler(rejectBtn, rejectAllHandler);
 
     // Customize button
-    const customizeBtn = document.getElementById('customize-preferences');
+    const customizeBtn = document.querySelector('#customize-preferences');
     if (customizeBtn && config.showModal) {
       customizeBtn.addEventListener('click', e => {
         // Store the element that triggered the modal opening
@@ -246,10 +251,10 @@ const _bannerAPI = (function () {
     // Modal events (if enabled)
     if (config.showModal) {
       // Close button
-      document.getElementById('close-modal').addEventListener('click', closeModal);
+      document.querySelector('#close-modal').addEventListener('click', closeModal);
 
       // Form submission
-      document.getElementById('cookie-form').addEventListener('submit', e => {
+      document.querySelector('#cookie-form').addEventListener('submit', e => {
         e.preventDefault();
         try {
           const form = e.target;
@@ -313,7 +318,7 @@ const _bannerAPI = (function () {
     isModalOpen = false;
 
     // Remove overlay
-    const overlay = document.getElementById('cookie-modal-overlay');
+    const overlay = document.querySelector('#cookie-modal-overlay');
     if (overlay) {
       overlay.remove();
     }
@@ -334,7 +339,7 @@ const _bannerAPI = (function () {
 
   /**
    * Get current consent settings from storage directly
-   * @returns {Object|null} - Consent object or null if no consent is stored
+   * @returns {object | null} - Consent object or null if no consent is stored
    */
   function getConsentFromStorage() {
     return readStoredConsent(config.storageMethod);
@@ -342,7 +347,7 @@ const _bannerAPI = (function () {
 
   /**
    * Get current consent settings (public API)
-   * @returns {Object|null} - Consent object or null if no consent is stored
+   * @returns {object | null} - Consent object or null if no consent is stored
    */
   function getConsent() {
     return getConsentFromStorage();
@@ -350,7 +355,7 @@ const _bannerAPI = (function () {
 
   /**
    * Set consent settings
-   * @param {Object} consent - Consent object with boolean values
+   * @param {object} consent - Consent object with boolean values
    */
   function setConsent(consent) {
     try {
@@ -383,7 +388,7 @@ const _bannerAPI = (function () {
 
   /**
    * Dispatch a custom event with consent data
-   * @param {Object} consentData - Consent data
+   * @param {object} consentData - Consent data
    */
   function dispatchConsentEvent(consentData) {
     const event = new CustomEvent('cookieConsentChanged', {

--- a/src/js/consent-manager.js
+++ b/src/js/consent-manager.js
@@ -1,5 +1,5 @@
 /**
- * @fileoverview Consent Manager - Handles storage, retrieval, and validation of cookie consent
+ * @file Consent Manager - Handles storage, retrieval, and validation of cookie consent
  * @module consent-manager
  * @author Karl Groves <karlgroves@gmail.com>
  * @version 1.0.0
@@ -8,8 +8,8 @@
 class ConsentManager {
   /**
    * Validate a consent object against expected schema (M1)
-   * @param {Object} obj - Object to validate
-   * @returns {Object|null} Validated consent or null
+   * @param {object} obj - Object to validate
+   * @returns {object | null} Validated consent or null
    */
   static validateConsent(obj) {
     if (typeof obj !== 'object' || obj === null || Array.isArray(obj)) {
@@ -37,7 +37,7 @@ class ConsentManager {
 
   /**
    * Create a new ConsentManager instance
-   * @param {Object} options - Configuration options
+   * @param {object} options - Configuration options
    * @param {string} options.storageMethod - 'localStorage' or 'cookie'
    * @param {number} options.expireDays - Number of days before consent expires
    * @param {Function} options.onConsentChange - Callback for consent changes
@@ -56,7 +56,7 @@ class ConsentManager {
 
   /**
    * Get current consent settings
-   * @returns {Object|null} - Consent object or null if no consent is stored
+   * @returns {object | null} - Consent object or null if no consent is stored
    */
   getConsent() {
     try {
@@ -79,7 +79,7 @@ class ConsentManager {
 
   /**
    * Set consent settings
-   * @param {Object} consent - Consent object with boolean values
+   * @param {object} consent - Consent object with boolean values
    */
   setConsent(consent) {
     // Ensure functional cookies are always enabled
@@ -136,7 +136,7 @@ class ConsentManager {
 
   /**
    * Dispatch a custom event with consent data
-   * @param {Object} consentData - Consent data
+   * @param {object} consentData - Consent data
    */
   dispatchConsentEvent(consentData) {
     try {

--- a/src/js/cookie-blocker-cookies.js
+++ b/src/js/cookie-blocker-cookies.js
@@ -1,5 +1,5 @@
 /**
- * @fileoverview document.cookie override for the cookie blocker: wraps the
+ * @file document.cookie override for the cookie blocker: wraps the
  * native cookie accessor so writes are vetted against the blocking rules,
  * with a simulated fallback for environments (like jsdom) where the native
  * descriptor is missing. Extracted from cookie-blocker.js (see
@@ -12,7 +12,7 @@
  * string, for environments where document.cookie is a simple value property
  * (e.g. some test environments).
  * @param {string} initialValue - Current document.cookie value
- * @returns {Object} Property descriptor with get/set
+ * @returns {object} Property descriptor with get/set
  */
 function createSimulatedCookieDescriptor(initialValue) {
   let cookieStorage = initialValue || '';
@@ -42,7 +42,7 @@ function createSimulatedCookieDescriptor(initialValue) {
 /**
  * Locate the original document.cookie accessor descriptor, falling back to a
  * simulated one when the environment exposes cookie as a plain value.
- * @returns {Object|null} A descriptor with get/set, or null when unusable
+ * @returns {object | null} A descriptor with get/set, or null when unusable
  */
 function resolveOriginalCookieDescriptor() {
   // Get the original cookie descriptor - try different locations

--- a/src/js/cookie-blocker-dom.js
+++ b/src/js/cookie-blocker-dom.js
@@ -1,5 +1,5 @@
 /**
- * @fileoverview DOM API overrides for the cookie blocker: intercepts script
+ * @file DOM API overrides for the cookie blocker: intercepts script
  * creation (document.createElement), insertion (appendChild/insertBefore),
  * and src assignment (setAttribute) so tracking scripts can be held back
  * until consent is granted. Extracted from cookie-blocker.js (see
@@ -42,10 +42,10 @@ export function appendChildBypassingBlock(parent, child) {
  * block record when the node must be held back, or null to let it through.
  * Shared by the appendChild and insertBefore overrides.
  * @param {Element} node - Node being inserted
- * @param {Object} handlers - Blocking predicates from the coordinator
+ * @param {object} handlers - Blocking predicates from the coordinator
  * @param {Function} handlers.shouldBlockScript - (src) => boolean
  * @param {Function} handlers.shouldBlockInlineScript - (content) => boolean
- * @returns {Object|null} Block record or null
+ * @returns {object | null} Block record or null
  */
 function classifyScriptInsertion(node, handlers) {
   // A manual data-category attribute takes precedence over pattern matching
@@ -61,7 +61,7 @@ function classifyScriptInsertion(node, handlers) {
  * unless the consent manager grants that category.
  * @param {Element} node - Script node
  * @param {string} dataCategory - Declared category
- * @returns {Object|null} Block record or null
+ * @returns {object | null} Block record or null
  */
 function classifyByDeclaredCategory(node, dataCategory) {
   const consentManager = window.CookieConsent;
@@ -81,8 +81,8 @@ function classifyByDeclaredCategory(node, dataCategory) {
  * Classify a script by its src URL or inline content against the blocking
  * predicates.
  * @param {Element} node - Script node
- * @param {Object} handlers - Blocking predicates from the coordinator
- * @returns {Object|null} Block record or null
+ * @param {object} handlers - Blocking predicates from the coordinator
+ * @returns {object | null} Block record or null
  */
 function classifyByContent(node, handlers) {
   // Check both external scripts and inline scripts
@@ -110,7 +110,7 @@ function classifyByContent(node, handlers) {
 /**
  * Override document.createElement to intercept script creation. Each created
  * script gets a guarded `src` setter that consults the blocking predicate.
- * @param {Object} handlers - Callbacks from the coordinator
+ * @param {object} handlers - Callbacks from the coordinator
  * @param {Function} handlers.shouldBlockScript - (src) => boolean
  * @param {Function} handlers.onBlocked - (record) => void
  */
@@ -133,7 +133,7 @@ export function overrideCreateElement(handlers) {
 /**
  * Install a src accessor on a script element that refuses blocked URLs.
  * @param {HTMLScriptElement} element - Script element to guard
- * @param {Object} handlers - Callbacks from the coordinator
+ * @param {object} handlers - Callbacks from the coordinator
  */
 function installGuardedSrcSetter(element, handlers) {
   // Store reference to the original src descriptor to properly set src on non-blocked scripts
@@ -168,7 +168,7 @@ function installGuardedSrcSetter(element, handlers) {
 
 /**
  * Override appendChild and insertBefore to intercept script insertion.
- * @param {Object} handlers - Callbacks from the coordinator
+ * @param {object} handlers - Callbacks from the coordinator
  * @param {Function} handlers.shouldBlockScript - (src) => boolean
  * @param {Function} handlers.shouldBlockInlineScript - (content) => boolean
  * @param {Function} handlers.onBlocked - (record) => void
@@ -202,7 +202,7 @@ export function overrideAppendMethods(handlers) {
 
 /**
  * Override setAttribute to catch dynamic src changes.
- * @param {Object} handlers - Callbacks from the coordinator
+ * @param {object} handlers - Callbacks from the coordinator
  * @param {Function} handlers.shouldBlockScript - (src) => boolean
  * @param {Function} handlers.onBlocked - (record) => void
  */

--- a/src/js/cookie-blocker-rules.js
+++ b/src/js/cookie-blocker-rules.js
@@ -1,5 +1,5 @@
 /**
- * @fileoverview Pattern tables and pure classification rules for the cookie
+ * @file Pattern tables and pure classification rules for the cookie
  * blocker: which cookies, script URLs, and inline snippets count as tracking,
  * and whether the current consent state allows them. Extracted from
  * cookie-blocker.js (see AFixt/cookie-banner#69).
@@ -114,7 +114,7 @@ export function getScriptCategory(src) {
  * manager. Pure with respect to module state — the caller supplies the
  * consent manager (or null when consent has not been given yet).
  * @param {string} cookieName - Name of the cookie to check
- * @param {Object|null} consentManager - window.CookieConsent or null
+ * @param {object | null} consentManager - window.CookieConsent or null
  * @returns {boolean} Whether the cookie should be blocked
  */
 export function cookieBlockDecision(cookieName, consentManager) {
@@ -138,7 +138,7 @@ export function cookieBlockDecision(cookieName, consentManager) {
  * Decide whether a script URL should be blocked given the current consent
  * manager. Pure with respect to module state.
  * @param {string} src - Script source URL to check
- * @param {Object|null} consentManager - window.CookieConsent or null
+ * @param {object | null} consentManager - window.CookieConsent or null
  * @returns {boolean} Whether the script should be blocked
  */
 export function scriptBlockDecision(src, consentManager) {

--- a/src/js/cookie-blocker.js
+++ b/src/js/cookie-blocker.js
@@ -1,5 +1,5 @@
 /**
- * @fileoverview Cookie Auto-blocking Module - Prevents tracking scripts and cookies from loading before user consent
+ * @file Cookie Auto-blocking Module - Prevents tracking scripts and cookies from loading before user consent
  * @module cookie-blocker
  * @author Karl Groves <karlgroves@gmail.com>
  * @version 1.0.0
@@ -34,7 +34,7 @@ const _blockerAPI = (function () {
 
   /**
    * Get the installed consent manager, if any
-   * @returns {Object|null} window.CookieConsent or null
+   * @returns {object | null} window.CookieConsent or null
    */
   function getConsentManager() {
     return typeof window !== 'undefined' && window.CookieConsent ? window.CookieConsent : null;
@@ -132,7 +132,7 @@ const _blockerAPI = (function () {
   /**
    * Check whether a consent object allows scripts of the given type
    * @param {string} type - Blocked script category
-   * @param {Object} consent - Consent detail from the change event
+   * @param {object} consent - Consent detail from the change event
    * @returns {boolean} True when the script may now execute
    */
   function consentAllowsType(type, consent) {
@@ -151,7 +151,7 @@ const _blockerAPI = (function () {
   /**
    * Re-create and execute a previously blocked script, copying its
    * attributes, using the original DOM methods so the override is bypassed.
-   * @param {Object} blockedItem - Record captured when the script was blocked
+   * @param {object} blockedItem - Record captured when the script was blocked
    */
   function executeBlockedScript(blockedItem) {
     const { element, src, innerHTML } = blockedItem;
@@ -214,7 +214,7 @@ const _blockerAPI = (function () {
   }
 
   /**
-   * @typedef {Object} BlockedScript
+   * @typedef {object} BlockedScript
    * @property {HTMLScriptElement} element - The blocked script element
    * @property {string} src - The source URL of the blocked script
    * @property {string} type - The type of script (e.g., 'analytics', 'marketing')

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -1,5 +1,5 @@
 /**
- * @fileoverview Accessible Cookie Banner - Entry point for the library
+ * @file Accessible Cookie Banner - Entry point for the library
  * @module cookie-banner
  * @author Karl Groves <karlgroves@gmail.com>
  * @version 1.0.0
@@ -23,7 +23,7 @@ import { initSubdomainSync } from './subdomain-sync.js';
  */
 
 /**
- * @typedef {Object} ConsentObject
+ * @typedef {object} ConsentObject
  * @property {boolean} functional - Always true, functional cookies are required
  * @property {boolean} analytics - Whether analytics cookies are allowed
  * @property {boolean} marketing - Whether marketing cookies are allowed
@@ -31,14 +31,14 @@ import { initSubdomainSync } from './subdomain-sync.js';
  */
 
 /**
- * @typedef {Object} CookieBannerConfig
+ * @typedef {object} CookieBannerConfig
  * @property {string} [locale='en'] - Language locale for the banner
  * @property {string} [theme='light'] - Theme for the banner ('light' or 'dark')
  * @property {boolean} [showModal=true] - Whether to show the preferences modal
  * @property {Function} [onConsentChange] - Callback function called when consent changes
  * @property {string} [storageMethod='localStorage'] - Storage method ('localStorage' or 'cookie')
  * @property {number} [expireDays=365] - Number of days before consent expires
- * @property {Object} [categories] - Default consent categories
+ * @property {object} [categories] - Default consent categories
  * @property {boolean} [categories.functional=true] - Functional cookies (always required)
  * @property {boolean} [categories.analytics=false] - Analytics cookies default
  * @property {boolean} [categories.marketing=false] - Marketing cookies default
@@ -120,6 +120,6 @@ if (typeof window !== 'undefined') {
 
 /**
  * Default export - the CookieBanner API or null in non-browser environments
- * @type {Object|null}
+ * @type {object | null}
  */
 export default typeof window !== 'undefined' ? window.CookieBanner : null;

--- a/src/js/subdomain-sync-html.js
+++ b/src/js/subdomain-sync-html.js
@@ -1,5 +1,5 @@
 /**
- * @fileoverview Generator for the static sync-endpoint HTML page that the
+ * @file Generator for the static sync-endpoint HTML page that the
  * primary domain hosts for postMessage-based consent synchronization.
  * Extracted from subdomain-sync.js (see AFixt/cookie-banner#69).
  * @module subdomain-sync-html
@@ -9,7 +9,7 @@ import { isValidDomain, filterValidSubdomains } from './subdomain-sync-validatio
 
 /**
  * Create sync endpoint HTML file content
- * @param {Object} config - Sync configuration (primaryDomain, allowedSubdomains)
+ * @param {object} config - Sync configuration (primaryDomain, allowedSubdomains)
  * @returns {string} HTML content for the sync endpoint
  */
 export function buildSyncEndpointHTML(config) {

--- a/src/js/subdomain-sync-validation.js
+++ b/src/js/subdomain-sync-validation.js
@@ -1,5 +1,5 @@
 /**
- * @fileoverview Validation and configuration preparation for subdomain
+ * @file Validation and configuration preparation for subdomain
  * consent synchronization: domain/subdomain patterns, consent schema checks,
  * endpoint vetting, and config sanitization. Extracted from
  * subdomain-sync.js (see AFixt/cookie-banner#69).
@@ -15,8 +15,10 @@ const DOMAIN_REGEX = /^[a-z0-9]([a-z0-9-]*[a-z0-9])?(\.[a-z0-9]([a-z0-9-]*[a-z0-
 /** Single-label subdomain pattern */
 const SUBDOMAIN_REGEX = /^[a-z0-9]([a-z0-9-]*[a-z0-9])?$/i;
 
-/** Allowed config keys to prevent prototype pollution. `currentHostname` is a
- *  documented test-only override consumed by `getCurrentHostname()`. */
+/**
+ * Allowed config keys to prevent prototype pollution. `currentHostname` is a
+ *  documented test-only override consumed by `getCurrentHostname()`.
+ */
 const ALLOWED_SYNC_CONFIG_KEYS = [
   'enabled',
   'primaryDomain',
@@ -47,8 +49,8 @@ export function filterValidSubdomains(subdomains) {
 
 /**
  * Sanitize config by allowlisting known keys and validating values
- * @param {Object} userConfig - User-provided configuration
- * @returns {Object} Sanitized configuration
+ * @param {object} userConfig - User-provided configuration
+ * @returns {object} Sanitized configuration
  */
 export function sanitizeConfig(userConfig) {
   const sanitized = {};
@@ -62,8 +64,8 @@ export function sanitizeConfig(userConfig) {
 
 /**
  * Validate a consent object against expected schema
- * @param {Object} obj - Object to validate
- * @returns {Object|null} Validated consent or null
+ * @param {object} obj - Object to validate
+ * @returns {object | null} Validated consent or null
  */
 export function validateConsentSchema(obj) {
   if (typeof obj !== 'object' || obj === null || Array.isArray(obj)) {
@@ -81,7 +83,7 @@ export function validateConsentSchema(obj) {
  * Validate that a sync endpoint URL is safe: HTTPS and on the primary domain
  * or an allowed subdomain of it.
  * @param {string} endpoint - URL to validate
- * @param {Object} config - Sync configuration (primaryDomain, allowedSubdomains)
+ * @param {object} config - Sync configuration (primaryDomain, allowedSubdomains)
  * @returns {boolean} Whether the endpoint is valid
  */
 export function isValidSyncEndpoint(endpoint, config) {
@@ -111,9 +113,9 @@ export function isValidSyncEndpoint(endpoint, config) {
  * Normalizes the subdomain list, clamps the sync interval, and drops an
  * invalid endpoint. Reports a status the initializer maps to its logging
  * and early-return behavior.
- * @param {Object} userConfig - User-provided configuration
- * @param {Object} defaultConfig - Module defaults
- * @returns {{config: Object, status: string}} Prepared config and one of
+ * @param {object} userConfig - User-provided configuration
+ * @param {object} defaultConfig - Module defaults
+ * @returns {{config: object, status: string}} Prepared config and one of
  *   'disabled' | 'invalid-domain' | 'ok'
  */
 export function prepareSyncConfig(userConfig, defaultConfig) {

--- a/src/js/subdomain-sync.js
+++ b/src/js/subdomain-sync.js
@@ -1,5 +1,5 @@
 /**
- * @fileoverview Subdomain Consent Synchronization - Enterprise feature for cross-subdomain consent sharing
+ * @file Subdomain Consent Synchronization - Enterprise feature for cross-subdomain consent sharing
  * @module subdomain-sync
  * @author Karl Groves <karlgroves@gmail.com>
  * @version 1.0.0
@@ -19,7 +19,7 @@ const _subdomainSyncAPI = (function () {
 
   /**
    * Configuration for subdomain sync
-   * @typedef {Object} SubdomainSyncConfig
+   * @typedef {object} SubdomainSyncConfig
    * @property {boolean} enabled - Whether subdomain sync is enabled
    * @property {string} primaryDomain - The primary domain for consent storage
    * @property {string[]} allowedSubdomains - List of allowed subdomains
@@ -125,7 +125,9 @@ const _subdomainSyncAPI = (function () {
     syncFrame.src = `https://${config.primaryDomain}/cookie-consent-sync.html`;
     syncFrame.sandbox = 'allow-scripts allow-same-origin';
 
-    // Wait for iframe to load
+    // Wait for iframe to load. The onload property (not addEventListener) is
+    // part of the module's tested contract — the suite invokes it directly.
+    // eslint-disable-next-line unicorn/prefer-add-event-listener
     syncFrame.onload = () => {
       // Request current consent from primary domain
       requestConsentSync();
@@ -227,7 +229,7 @@ const _subdomainSyncAPI = (function () {
 
   /**
    * Handle remote consent data
-   * @param {Object} remoteConsent - Consent data from remote domain
+   * @param {object} remoteConsent - Consent data from remote domain
    * @returns {void}
    */
   function handleRemoteConsent(remoteConsent) {
@@ -298,7 +300,7 @@ const _subdomainSyncAPI = (function () {
 
   /**
    * Push consent to API endpoint
-   * @param {Object} consent - Consent data to push
+   * @param {object} consent - Consent data to push
    * @returns {Promise<void>}
    */
   async function pushConsentToAPI(consent) {
@@ -355,7 +357,7 @@ const _subdomainSyncAPI = (function () {
 
   /**
    * Get sync status information
-   * @returns {Object} Sync status
+   * @returns {object} Sync status
    */
   function getSyncStatus() {
     return {

--- a/test/accessibility.test.js
+++ b/test/accessibility.test.js
@@ -126,7 +126,7 @@ describe('Accessibility Features', () => {
       const form = document.getElementById('cookie-form');
       const fieldsets = form.querySelectorAll('fieldset');
 
-      expect(fieldsets.length).toBe(3);
+      expect(fieldsets).toHaveLength(3);
 
       fieldsets.forEach(fieldset => {
         const legend = fieldset.querySelector('legend');
@@ -138,7 +138,7 @@ describe('Accessibility Features', () => {
     test('should have descriptive text for each cookie category', () => {
       const descriptions = document.querySelectorAll('.cookie-description');
 
-      expect(descriptions.length).toBe(3);
+      expect(descriptions).toHaveLength(3);
 
       descriptions.forEach(description => {
         expect(description.textContent.length).toBeGreaterThan(10);

--- a/test/git-hooks.test.js
+++ b/test/git-hooks.test.js
@@ -60,8 +60,12 @@ describe('Husky hooks', () => {
 
   it('runs the full check suite and tests before each push', () => {
     const commands = hookCommands('pre-push').join('\n');
-    expect(commands).toMatch(/npm run check/);
-    expect(commands).toMatch(/npm test/);
+    expect(commands).toMatch(/npm run check:all/);
+
+    // check:all must keep the test suite inside the push gate
+    const pkg = JSON.parse(fs.readFileSync(path.join(__dirname, '..', 'package.json'), 'utf8'));
+    expect(pkg.scripts['check:all']).toMatch(/npm run check/);
+    expect(pkg.scripts['check:all']).toMatch(/npm test/);
   });
 
   it('validates commit messages against commitlint', () => {

--- a/test/index-integration.test.js
+++ b/test/index-integration.test.js
@@ -32,10 +32,19 @@ describe('Index.js Integration', () => {
     jest.resetModules();
   });
 
-  // All tests have been temporarily removed due to failures
-  // TODO: Investigate and fix integration test issues
+  // The full integration suite was removed due to failures and still needs
+  // reinstating — see the TODO in the repo issue tracker. These smoke tests
+  // at least pin the module's global surface in the meantime.
 
-  test('placeholder test - tests removed due to failures', () => {
-    expect(true).toBe(true);
+  test('loading the entry point exposes the public globals', () => {
+    require('../src/js/index.js');
+
+    expect(window.initCookieBanner).toBeInstanceOf(Function);
+    expect(window.CookieConsent).toBeDefined();
+    expect(window.CookieConsent.getConsent).toBeInstanceOf(Function);
+    expect(window.CookieConsent.setConsent).toBeInstanceOf(Function);
+    expect(window.CookieConsent.hasConsent).toBeInstanceOf(Function);
+    expect(window.CookieBlocker).toBeDefined();
+    expect(window.CookieBlocker.init).toBeInstanceOf(Function);
   });
 });

--- a/test/node-version-consistency.test.js
+++ b/test/node-version-consistency.test.js
@@ -37,9 +37,9 @@ describe('Node version consistency', () => {
       .filter(f => /\.ya?ml$/.test(f))
       .forEach(file => {
         const yaml = fs.readFileSync(path.join(workflowDir, file), 'utf8');
-        const versions = [...yaml.matchAll(/node-version:\s*\[?\s*['"]?([^'"\]\s]+)/g)].map(
-          m => m[1]
-        );
+        const versions = [
+          ...yaml.matchAll(/node-version:[ \t]*(?:\[[ \t]*)?['"]?([^'"\]\s]+)/g),
+        ].map(m => m[1]);
         versions.forEach(version => {
           // Accept forms like 22, 22.x, ${{ matrix.node-version }} (resolved
           // from a matrix that is itself checked by this loop).


### PR DESCRIPTION
## Summary
Closes the applicable remainder of #62, honoring its ground rule: nothing that already works was replaced. Much of the stack landed in #68; this PR fills the gaps and documents every decision.

### Added
- **ESLint plugins** for a vanilla-JS library: `sonarjs`, `promise`, `import-x` (global); `security`, `jsdoc`, targeted `unicorn` subset (`src/**`); `no-secrets` as a second layer behind gitleaks. Lands at **0 errors**; 42 advisory warnings (jsdoc descriptions, security hints) guide future work.
- **ADR 0001** (`docs/adr/`) recording keep/replace/skip decisions, plus README/ADR templates in `docs/templates/`.
- **`npm run lint:licenses`** — license allowlist via `license-checker-rseidelsohn`.
- **`npm run check:all`** — aggregate local gate (check + jscpd + licenses + tests); **pre-push now runs it**.
- **post-merge hook** — auto `npm install` when the lockfile changes.
- **`scripts/bootstrap.sh`** — installs optional scanner binaries (gitleaks, semgrep, osv-scanner, lychee).
- **Weekly `link-check.yml`** — lychee link-rot check that files an issue on failures.
- Placeholder integration test replaced with a real smoke test pinning the entry point's globals.

### Deliberately skipped (documented in ADR 0001)
- TypeScript/ts-reset migration (plain JS + lint-enforced JSDoc kept)
- Vitest (Jest suite healthy), Lighthouse/ZAP (nothing deployed), Express hardening (no server)
- **Dependabot config** — the issue asks to commit one, but Dependabot was deliberately removed today (PR #85); owner decision supersedes
- `@afix/a11y-assert` — private package; existing axe/Playwright a11y layers remain (deferred in ADR)

### Note
`typescript@~5.9` enters devDependencies only because `eslint-plugin-sonarjs` needs the TS API at lint time (TS 7 breaks `ts-api-utils`).

## Testing
- `npm run check:all` passes end-to-end (lint 0 errors, prettier, stylelint, markdownlint, jscpd, licenses, 239/239 tests)
- `npm run build` and `npm run size` clean
- Installs done on Node 22/npm 10 per the #71 pin; lockfile updated incrementally

Refs #62