### PR TITLE
refactor(lint): Clear all 42 ESLint warnings

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -3,9 +3,9 @@ import globals from 'globals';
 import sonarjs from 'eslint-plugin-sonarjs';
 import security from 'eslint-plugin-security';
 import unicorn from 'eslint-plugin-unicorn';
-import importX from 'eslint-plugin-import-x';
+import { importX } from 'eslint-plugin-import-x';
 import promise from 'eslint-plugin-promise';
-import jsdoc from 'eslint-plugin-jsdoc';
+import jsdocPlugin from 'eslint-plugin-jsdoc';
 import noSecrets from 'eslint-plugin-no-secrets';
 
 /** @type {import('eslint').Linter.Config[]} */
@@ -79,7 +79,7 @@ export default [
     plugins: {
       security,
       unicorn,
-      jsdoc,
+      jsdoc: jsdocPlugin,
     },
     rules: {
       // Size and complexity limits (see #62/#69). Source only — test files
@@ -108,7 +108,7 @@ export default [
       'unicorn/explicit-length-check': 'off',
 
       // Documentation: every exported/public function keeps meaningful JSDoc
-      ...jsdoc.configs['flat/recommended'].rules,
+      ...jsdocPlugin.configs['flat/recommended'].rules,
       'jsdoc/require-jsdoc': [
         'warn',
         { publicOnly: false, require: { FunctionDeclaration: true } },

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -3,7 +3,7 @@
  */
 
 import terser from '@rollup/plugin-terser';
-import babel from '@rollup/plugin-babel';
+import { babel } from '@rollup/plugin-babel';
 import resolve from '@rollup/plugin-node-resolve';
 import commonjs from '@rollup/plugin-commonjs';
 import json from '@rollup/plugin-json';

--- a/src/js/banner-dom.js
+++ b/src/js/banner-dom.js
@@ -25,7 +25,7 @@ function applyTheme(element, theme) {
  * @param {string} id - Element id
  * @param {string} action - data-action value
  * @param {string} label - Visible button text
- * @returns {HTMLButtonElement}
+ * @returns {HTMLButtonElement} The configured action button
  */
 function buildBannerButton(id, action, label) {
   const button = document.createElement('button');
@@ -83,7 +83,7 @@ export function createBannerElement(config, strings) {
  * @param {boolean} options.disabled - Whether the checkbox is locked
  * @param {string} options.label - Visible label text
  * @param {string} [options.description] - Optional description text
- * @returns {HTMLDivElement}
+ * @returns {HTMLDivElement} The category row container
  */
 function buildCategoryRow({ name, checked, disabled, label, description }) {
   const container = document.createElement('div');
@@ -116,7 +116,7 @@ function buildCategoryRow({ name, checked, disabled, label, description }) {
  * Create the fieldset grouping all cookie-category checkboxes
  * @param {object} config - Banner configuration
  * @param {object} strings - Locale strings
- * @returns {HTMLFieldSetElement}
+ * @returns {HTMLFieldSetElement} The fieldset grouping all category checkboxes
  */
 function buildCategoryFieldset(config, strings) {
   const fieldset = document.createElement('fieldset');
@@ -158,7 +158,7 @@ function buildCategoryFieldset(config, strings) {
 /**
  * Create the modal action buttons (save / cancel)
  * @param {object} strings - Locale strings
- * @returns {HTMLDivElement}
+ * @returns {HTMLDivElement} The container holding the save and cancel buttons
  */
 function buildModalActions(strings) {
   const actions = document.createElement('div');

--- a/src/js/banner.js
+++ b/src/js/banner.js
@@ -43,8 +43,11 @@ const _bannerAPI = (function () {
     'categories',
   ];
 
-  /** Locale format pattern (M4) */
-  const LOCALE_REGEX = /^[a-z]{2}(-[A-Z]{2})?$/;
+  /**
+   * Locale format pattern (M4). Written without nested quantifiers so the
+   * match is linear-time (security/detect-unsafe-regex).
+   */
+  const LOCALE_REGEX = /^[a-z][a-z](?:-[A-Z][A-Z])?$/;
 
   // State
   let config = {};
@@ -57,6 +60,8 @@ const _bannerAPI = (function () {
   /**
    * Initialize the cookie banner
    * @param {object} userConfig - Configuration options
+   * @returns {Promise<void>} Resolves once the banner is rendered, or
+   * immediately when stored consent already exists
    */
   function initCookieBanner(userConfig = {}) {
     try {
@@ -116,7 +121,8 @@ const _bannerAPI = (function () {
   /**
    * Load locale strings based on configured locale
    * @param {string} locale - Locale code (e.g., 'en')
-   * @returns {Promise}
+   * @returns {Promise<void>} Resolves once locale strings are loaded, falling
+   * back to English on any failure
    */
   function loadLocaleStrings(locale) {
     return new Promise(resolve => {
@@ -175,8 +181,8 @@ const _bannerAPI = (function () {
 
   /**
    * Add keyboard event handler to button
-   * @param button
-   * @param callback
+   * @param {HTMLElement} button - Button to attach the handler to
+   * @param {function(): void} callback - Invoked when Enter or Space is pressed
    */
   function addKeyboardHandler(button, callback) {
     button.addEventListener('keydown', e => {

--- a/src/js/consent-manager.js
+++ b/src/js/consent-manager.js
@@ -40,7 +40,7 @@ class ConsentManager {
    * @param {object} options - Configuration options
    * @param {string} options.storageMethod - 'localStorage' or 'cookie'
    * @param {number} options.expireDays - Number of days before consent expires
-   * @param {Function} options.onConsentChange - Callback for consent changes
+   * @param {function(object): void} options.onConsentChange - Callback for consent changes
    */
   constructor(options = {}) {
     this.options = {
@@ -80,6 +80,7 @@ class ConsentManager {
   /**
    * Set consent settings
    * @param {object} consent - Consent object with boolean values
+   * @returns {object | null} The stored consent data, or null when storage failed
    */
   setConsent(consent) {
     // Ensure functional cookies are always enabled

--- a/src/js/cookie-blocker-cookies.js
+++ b/src/js/cookie-blocker-cookies.js
@@ -66,7 +66,7 @@ function resolveOriginalCookieDescriptor() {
  * Override document.cookie so writes are vetted by the supplied predicate.
  * Blocked writes are logged and dropped; failures in the blocking logic fail
  * closed (the cookie is not set — L4).
- * @param {Function} shouldBlockCookie - (cookieName) => boolean
+ * @param {function(string): boolean} shouldBlockCookie - (cookieName) => boolean
  */
 export function overrideCookieProperty(shouldBlockCookie) {
   // Check if cookie property has already been overridden by us
@@ -126,7 +126,7 @@ export function overrideCookieProperty(shouldBlockCookie) {
 
 /**
  * Expire existing cookies that the blocking predicate rejects.
- * @param {Function} shouldBlockCookie - (cookieName) => boolean
+ * @param {function(string): boolean} shouldBlockCookie - (cookieName) => boolean
  */
 export function blockExistingCookies(shouldBlockCookie) {
   const cookies = document.cookie.split(';');

--- a/src/js/cookie-blocker-dom.js
+++ b/src/js/cookie-blocker-dom.js
@@ -19,7 +19,7 @@ let originalSetAttribute = null;
  * Create an element bypassing the createElement override (used to execute
  * previously blocked scripts once consent arrives).
  * @param {string} tagName - Tag to create
- * @returns {Element}
+ * @returns {Element} The element created via the original createElement
  */
 export function createElementBypassingBlock(tagName) {
   const create = originalCreateElement || document.createElement;
@@ -30,7 +30,7 @@ export function createElementBypassingBlock(tagName) {
  * Append a child bypassing the appendChild override.
  * @param {Element} parent - Parent element
  * @param {Element} child - Child to append
- * @returns {Element}
+ * @returns {Element} The appended child
  */
 export function appendChildBypassingBlock(parent, child) {
   const append = originalAppendChild || Element.prototype.appendChild;
@@ -43,8 +43,8 @@ export function appendChildBypassingBlock(parent, child) {
  * Shared by the appendChild and insertBefore overrides.
  * @param {Element} node - Node being inserted
  * @param {object} handlers - Blocking predicates from the coordinator
- * @param {Function} handlers.shouldBlockScript - (src) => boolean
- * @param {Function} handlers.shouldBlockInlineScript - (content) => boolean
+ * @param {function(string): boolean} handlers.shouldBlockScript - (src) => boolean
+ * @param {function(string): boolean} handlers.shouldBlockInlineScript - (content) => boolean
  * @returns {object | null} Block record or null
  */
 function classifyScriptInsertion(node, handlers) {
@@ -111,8 +111,8 @@ function classifyByContent(node, handlers) {
  * Override document.createElement to intercept script creation. Each created
  * script gets a guarded `src` setter that consults the blocking predicate.
  * @param {object} handlers - Callbacks from the coordinator
- * @param {Function} handlers.shouldBlockScript - (src) => boolean
- * @param {Function} handlers.onBlocked - (record) => void
+ * @param {function(string): boolean} handlers.shouldBlockScript - (src) => boolean
+ * @param {function(object): void} handlers.onBlocked - (record) => void
  */
 export function overrideCreateElement(handlers) {
   originalCreateElement = document.createElement;
@@ -169,9 +169,9 @@ function installGuardedSrcSetter(element, handlers) {
 /**
  * Override appendChild and insertBefore to intercept script insertion.
  * @param {object} handlers - Callbacks from the coordinator
- * @param {Function} handlers.shouldBlockScript - (src) => boolean
- * @param {Function} handlers.shouldBlockInlineScript - (content) => boolean
- * @param {Function} handlers.onBlocked - (record) => void
+ * @param {function(string): boolean} handlers.shouldBlockScript - (src) => boolean
+ * @param {function(string): boolean} handlers.shouldBlockInlineScript - (content) => boolean
+ * @param {function(object): void} handlers.onBlocked - (record) => void
  */
 export function overrideAppendMethods(handlers) {
   originalAppendChild = Element.prototype.appendChild;
@@ -203,8 +203,8 @@ export function overrideAppendMethods(handlers) {
 /**
  * Override setAttribute to catch dynamic src changes.
  * @param {object} handlers - Callbacks from the coordinator
- * @param {Function} handlers.shouldBlockScript - (src) => boolean
- * @param {Function} handlers.onBlocked - (record) => void
+ * @param {function(string): boolean} handlers.shouldBlockScript - (src) => boolean
+ * @param {function(object): void} handlers.onBlocked - (record) => void
  */
 export function overrideSetAttribute(handlers) {
   originalSetAttribute = Element.prototype.setAttribute;

--- a/src/js/cookie-blocker.js
+++ b/src/js/cookie-blocker.js
@@ -43,7 +43,6 @@ const _blockerAPI = (function () {
   /**
    * Initialize the cookie blocker - sets up script and cookie blocking mechanisms
    * @function
-   * @memberof CookieBlocker
    * @returns {void}
    * @example
    * // Initialize cookie blocker

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -35,7 +35,7 @@ import { initSubdomainSync } from './subdomain-sync.js';
  * @property {string} [locale='en'] - Language locale for the banner
  * @property {string} [theme='light'] - Theme for the banner ('light' or 'dark')
  * @property {boolean} [showModal=true] - Whether to show the preferences modal
- * @property {Function} [onConsentChange] - Callback function called when consent changes
+ * @property {function(object): void} [onConsentChange] - Callback function called when consent changes
  * @property {string} [storageMethod='localStorage'] - Storage method ('localStorage' or 'cookie')
  * @property {number} [expireDays=365] - Number of days before consent expires
  * @property {object} [categories] - Default consent categories
@@ -54,10 +54,10 @@ if (typeof window !== 'undefined') {
   /**
    * Global cookie banner API
    * @namespace window.CookieBanner
-   * @property {Function} init - Initialize the cookie banner
-   * @property {Function} getConsent - Get current consent status
-   * @property {Function} setConsent - Set consent status
-   * @property {Function} hasConsent - Check if a specific category has consent
+   * @property {function(CookieBannerConfig=): void} init - Initialize the cookie banner
+   * @property {function(): (object | null)} getConsent - Get current consent status
+   * @property {function(object): (object | null)} setConsent - Set consent status
+   * @property {function(string): boolean} hasConsent - Check if a specific category has consent
    */
   window.CookieBanner = {
     /**
@@ -93,6 +93,7 @@ if (typeof window !== 'undefined') {
      * @function
      * @memberof window.CookieBanner
      * @param {ConsentObject} consent - Consent object with boolean values
+     * @returns {object | null} The stored consent data, or null when unavailable
      * @example
      * window.CookieBanner.setConsent({
      *   functional: true,

--- a/src/js/subdomain-sync-validation.js
+++ b/src/js/subdomain-sync-validation.js
@@ -9,11 +9,13 @@
 /** Minimum allowed sync interval in ms */
 export const MIN_SYNC_INTERVAL = 1000;
 
-/** Strict domain name pattern */
-const DOMAIN_REGEX = /^[a-z0-9]([a-z0-9-]*[a-z0-9])?(\.[a-z0-9]([a-z0-9-]*[a-z0-9])?)*$/i;
-
-/** Single-label subdomain pattern */
-const SUBDOMAIN_REGEX = /^[a-z0-9]([a-z0-9-]*[a-z0-9])?$/i;
+/**
+ * Single DNS label: alphanumeric at both ends, hyphens allowed between.
+ * Written without nested quantifiers so the match is linear-time
+ * (security/detect-unsafe-regex); full domains are validated label by label
+ * in `isValidDomain` rather than with one nested-repetition pattern.
+ */
+const DOMAIN_LABEL_REGEX = /^(?:[a-z0-9]|[a-z0-9][a-z0-9-]*[a-z0-9])$/i;
 
 /**
  * Allowed config keys to prevent prototype pollution. `currentHostname` is a
@@ -35,7 +37,11 @@ const ALLOWED_SYNC_CONFIG_KEYS = [
  * @returns {boolean} Whether the domain is valid
  */
 export function isValidDomain(domain) {
-  return typeof domain === 'string' && DOMAIN_REGEX.test(domain) && domain.length <= 253;
+  return (
+    typeof domain === 'string' &&
+    domain.length <= 253 &&
+    domain.split('.').every(label => DOMAIN_LABEL_REGEX.test(label))
+  );
 }
 
 /**
@@ -44,7 +50,7 @@ export function isValidDomain(domain) {
  * @returns {string[]} Valid subdomains
  */
 export function filterValidSubdomains(subdomains) {
-  return (subdomains || []).filter(s => typeof s === 'string' && SUBDOMAIN_REGEX.test(s));
+  return (subdomains || []).filter(s => typeof s === 'string' && DOMAIN_LABEL_REGEX.test(s));
 }
 
 /**

--- a/src/js/subdomain-sync.js
+++ b/src/js/subdomain-sync.js
@@ -80,7 +80,7 @@ const _subdomainSyncAPI = (function () {
   /**
    * Resolve the current hostname. Tests may override by setting
    * `currentHostname` in the config passed to `init`.
-   * @returns {string}
+   * @returns {string} The effective hostname
    */
   function getCurrentHostname() {
     return config.currentHostname || window.location.hostname;
@@ -265,7 +265,7 @@ const _subdomainSyncAPI = (function () {
 
   /**
    * Check the configured endpoint is present and still valid before use
-   * @returns {boolean}
+   * @returns {boolean} True when an endpoint is configured and passes validation
    */
   function hasValidEndpoint() {
     return !!config.syncEndpoint && isValidSyncEndpoint(config.syncEndpoint, config);

--- a/test/banner.test.js
+++ b/test/banner.test.js
@@ -202,6 +202,24 @@ describe('Banner Functionality', () => {
         "Invalid locale format 'invalid', using default English."
       );
     });
+
+    // Pins the locale pattern rewritten without nested quantifiers
+    // (security/detect-unsafe-regex cleanup): ll or ll-CC only.
+    test('accepts region-qualified locales and rejects near-misses', async () => {
+      global.fetch = jest.fn().mockResolvedValue({ ok: false });
+      mockConsentManager.getConsent.mockReturnValue(null);
+
+      await window.initCookieBanner({ locale: 'en-US' });
+      expect(global.fetch).toHaveBeenCalledWith('locales/en-US.json');
+
+      for (const locale of ['EN', 'en-us', 'eng', 'e']) {
+        console.warn.mockClear();
+        await window.initCookieBanner({ locale });
+        expect(console.warn).toHaveBeenCalledWith(
+          `Invalid locale format '${locale}', using default English.`
+        );
+      }
+    });
   });
 
   describe('Banner Creation', () => {

--- a/test/index-integration.test.js
+++ b/test/index-integration.test.js
@@ -33,8 +33,8 @@ describe('Index.js Integration', () => {
   });
 
   // The full integration suite was removed due to failures and still needs
-  // reinstating — see the TODO in the repo issue tracker. These smoke tests
-  // at least pin the module's global surface in the meantime.
+  // reinstating — tracked in the repo issue tracker. These smoke tests at
+  // least pin the module's global surface in the meantime.
 
   test('loading the entry point exposes the public globals', () => {
     require('../src/js/index.js');

--- a/test/subdomain-sync-validation.test.js
+++ b/test/subdomain-sync-validation.test.js
@@ -39,6 +39,18 @@ describe('subdomain-sync-validation', () => {
       expect(isValidDomain('a'.repeat(254))).toBe(false);
       expect(isValidDomain(42)).toBe(false);
     });
+
+    // Pins the label-by-label validation that replaced the single
+    // nested-repetition pattern (security/detect-unsafe-regex cleanup).
+    test('handles label edge cases like the original pattern', () => {
+      expect(isValidDomain('a.io')).toBe(true);
+      expect(isValidDomain('my-app.example.com')).toBe(true);
+      expect(isValidDomain('')).toBe(false);
+      expect(isValidDomain('a..b')).toBe(false);
+      expect(isValidDomain('example.com.')).toBe(false);
+      expect(isValidDomain('bad-.com')).toBe(false);
+      expect(isValidDomain('.example.com')).toBe(false);
+    });
   });
 
   describe('filterValidSubdomains', () => {
@@ -48,6 +60,10 @@ describe('subdomain-sync-validation', () => {
         'www2',
       ]);
       expect(filterValidSubdomains(undefined)).toEqual([]);
+    });
+
+    test('keeps single-character labels and rejects hyphen edges', () => {
+      expect(filterValidSubdomains(['a', 'my-app', '-app', 'app-', ''])).toEqual(['a', 'my-app']);
     });
   });
 


### PR DESCRIPTION
Follow-up to #93: the tooling stack landed with 0 errors but 42 warnings. This clears every one — `npm run lint` now reports **0 problems** — with real fixes rather than suppressions.

## Unsafe-regex rewrites (the only behavioral surface)

`security/detect-unsafe-regex` (safe-regex) flags any nested quantifier, including bounded ones:

- `LOCALE_REGEX` in `banner.js`: `/^[a-z]{2}(-[A-Z]{2})?$/` → `/^[a-z][a-z](?:-[A-Z][A-Z])?$/` — same language, star-height 1.
- `subdomain-sync-validation.js`: the multi-label `DOMAIN_REGEX` is replaced by a single linear-time label pattern applied per label via `split('.')`; `SUBDOMAIN_REGEX` folds into the same `DOMAIN_LABEL_REGEX`.

**New tests pin equivalence**: single-char labels, hyphen-edge labels (`-app`/`app-`), empty labels (`a..b`, trailing dot, leading dot, empty string), and locale near-misses (`EN`, `en-us`, `eng`, `e`) vs `en-US`. 246 tests pass (3 new).

## Import hygiene

- `eslint.config.mjs`: named `importX` export (kills both no-named-as-default and the `flatConfigs` member warning); `jsdoc` default import renamed to `jsdocPlugin` (the package's named `jsdoc` export is not the plugin object — it lacks `.configs`).
- `rollup.config.js`: named `babel` export.

## JSDoc precision (36 of the 42)

Missing `@returns` declarations/descriptions and param types filled in; bare `{Function}` types replaced with concrete signatures (`function(string): boolean` etc.) in `consent-manager`, `cookie-blocker-*`, `banner*`, `index`, `subdomain-sync`. Dropped an `@memberof` referencing the undefined `CookieBlocker` type; reworded a test comment that tripped `sonarjs/todo-tag`.

## Verification

- `npm run lint`: 0 problems (was 0 errors / 42 warnings)
- `npm run check` exit 0 (lint + prettier + stylelint + markdownlint)
- `npm run build && npm test` (Node 24.15.0): 16 suites, 246 tests pass