### PR TITLE
fix(ci): Remove all scheduled (cron) triggers from workflows

### DIFF
--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -1,15 +1,18 @@
 name: Link Check
 
+# Policy: no scheduled (cron) Actions. Link integrity is checked on the pull
+# request that could break it (offline mode — internal/relative links, fast),
+# with `workflow_dispatch` available for a manual full external-URL sweep.
 on:
-  schedule:
-    # Weekly, Monday 06:30 UTC — external links rot on their own schedule,
-    # not per-commit, so this is not a PR gate.
-    - cron: '30 6 * * 1'
+  pull_request:
+    branches: [main, develop]
+    paths:
+      - '**/*.md'
+      - 'docs/**'
   workflow_dispatch:
 
 permissions:
   contents: read
-  issues: write
 
 jobs:
   lychee:
@@ -19,8 +22,24 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
 
-      - name: Run lychee
-        id: lychee
+      # PR runs check internal/relative links only (--offline): fast, and a
+      # failure is attributable to the change under review. Manual runs check
+      # external URLs too, since link rot is not attributable to any PR.
+      - name: Run lychee (offline — pull request)
+        if: github.event_name == 'pull_request'
+        uses: lycheeverse/lychee-action@e7477775783ea5526144ba13e8db5eec57747ce8 # v2
+        with:
+          args: >-
+            --no-progress
+            --offline
+            --exclude-path node_modules
+            --exclude-path dist
+            --exclude-path CHANGELOG.md
+            './**/*.md'
+          fail: true
+
+      - name: Run lychee (full — manual)
+        if: github.event_name == 'workflow_dispatch'
         uses: lycheeverse/lychee-action@e7477775783ea5526144ba13e8db5eec57747ce8 # v2
         with:
           args: >-
@@ -29,12 +48,4 @@ jobs:
             --exclude-path dist
             --exclude-path CHANGELOG.md
             './**/*.md'
-          fail: false
-
-      - name: Open an issue when links are broken
-        if: steps.lychee.outputs.exit_code != 0
-        uses: peter-evans/create-issue-from-file@e8ef132d6df98ed982188e460ebb3b5d4ef3a9cd # v5
-        with:
-          title: 'Link check: broken links found'
-          content-filepath: ./lychee/out.md
-          labels: documentation
+          fail: true

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,12 +1,11 @@
 name: Security Scanning
 
-# The OWASP Dependency Check and licence jobs below are gated on
-# `schedule`/`workflow_dispatch`. Until this schedule was added they could
-# never run, because the workflow had no schedule trigger at all.
+# Policy: no scheduled (cron) Actions. The PR-time gates are `npm audit`
+# (here) and the licence allowlist (`npm run lint:licenses` in ci.yml).
+# The heavier OWASP Dependency Check and the duplicate licence report are
+# manual-only (`workflow_dispatch`) — a timer-triggered failure is
+# attributable to nobody and gets ignored.
 on:
-  schedule:
-    # Weekly, Monday 06:00 UTC.
-    - cron: '0 6 * * 1'
   pull_request:
     branches: [main, develop]
   workflow_dispatch:
@@ -56,11 +55,11 @@ jobs:
   # Do not add a custom CodeQL job here as it will conflict with the default setup.
   # To configure CodeQL, go to: Repository Settings > Code security and analysis > CodeQL analysis
 
-  # OWASP Dependency Check (comprehensive - weekly only)
+  # OWASP Dependency Check (comprehensive — manual runs only; heavy NVD download)
   owasp-dependency-check:
     name: OWASP Dependency Check
     runs-on: ubuntu-latest
-    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+    if: github.event_name == 'workflow_dispatch'
     steps:
       - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
 
@@ -103,11 +102,12 @@ jobs:
           sarif_file: reports/dependency-check-report.sarif
         if: always()
 
-  # License compliance check
+  # License compliance report (manual only — the PR gate is `npm run
+  # lint:licenses` in ci.yml; this job just produces the full JSON report)
   license-check:
     name: License Compliance
     runs-on: ubuntu-latest
-    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+    if: github.event_name == 'workflow_dispatch'
     steps:
       - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
 

--- a/test/workflows.test.js
+++ b/test/workflows.test.js
@@ -2,7 +2,10 @@
  * Guards for the GitHub Actions layout.
  *
  * Issue #62 reduces Actions to a safety net: one blocking `ci.yml`, a
- * `release.yml`, and two scheduled workflows. The failure modes this file
+ * `release.yml`, and two on-demand workflows (`security.yml`,
+ * `link-check.yml`). Issue #103 removes every cron schedule: checks run on
+ * pull requests, where a failure is attributable to the change that caused
+ * it, with `workflow_dispatch` for manual runs. The failure modes this file
  * exists to catch have all already happened here:
  *
  * - `security.yml` gated two jobs on `schedule` while the workflow had no
@@ -127,19 +130,42 @@ describe('npm authentication', () => {
   );
 });
 
-describe('scheduled workflows', () => {
-  it.each(['security.yml', 'link-check.yml'])('%s has a cron schedule', name => {
-    const lines = workflow(name).split('\n');
-    const scheduleIndex = lines.findIndex(line => /^\s*schedule:\s*$/.test(line));
-    expect(scheduleIndex).toBeGreaterThan(-1);
-    expect(lines.slice(scheduleIndex).some(line => /^\s*- cron:/.test(line))).toBe(true);
+describe('no scheduled workflows (issue #103)', () => {
+  // Policy: no regularly scheduled GitHub Action, ever. A timer-triggered
+  // check reports failures against no particular change and gets ignored;
+  // the same check on a pull request gates the defect at introduction.
+  // `workflow_dispatch` (manual runs) remains allowed.
+  it('no workflow has a schedule or cron trigger', () => {
+    const files = fs.readdirSync(WORKFLOW_DIR).filter(name => /\.ya?ml$/.test(name));
+    for (const name of files) {
+      const lines = workflow(name).split('\n');
+      expect(lines.some(line => line.trim() === 'schedule:')).toBe(false);
+      expect(lines.some(line => line.trim().startsWith('- cron:'))).toBe(false);
+    }
   });
 
-  it('security.yml schedules the jobs that are gated on the schedule event', () => {
+  it('no job is gated on the schedule event', () => {
+    const files = fs.readdirSync(WORKFLOW_DIR).filter(name => /\.ya?ml$/.test(name));
+    for (const name of files) {
+      // A job gated on `github.event_name == 'schedule'` is dead code once no
+      // schedule trigger exists — the inverse of how OWASP Dependency Check
+      // once never ran. Gate manual-only jobs on `workflow_dispatch` instead.
+      expect(workflow(name)).not.toMatch(/github\.event_name == 'schedule'/);
+    }
+  });
+
+  it('link-check.yml runs the link check on pull requests', () => {
+    const contents = workflow('link-check.yml');
+    expect(contents).toMatch(/pull_request:/);
+    expect(contents).toMatch(/--offline/);
+    expect(contents).toMatch(/fail: true/);
+    // No timer-triggered auto-filed issues: the PR failure is the signal.
+    expect(contents).not.toMatch(/create-issue-from-file/);
+  });
+
+  it('security.yml keeps its manual-only jobs runnable via workflow_dispatch', () => {
     const contents = workflow('security.yml');
-    // Every `if: github.event_name == 'schedule'` job is dead code without a
-    // schedule trigger. This is exactly how OWASP Dependency Check never ran.
-    expect(contents).toMatch(/github\.event_name == 'schedule'/);
-    expect(contents).toMatch(/- cron:/);
+    expect(contents).toMatch(/workflow_dispatch:/);
+    expect(contents).toMatch(/github\.event_name == 'workflow_dispatch'/);
   });
 });


### PR DESCRIPTION
Fixes #103

## What changed

- **link-check.yml** — weekly cron and timer-filed issues removed. The link check now runs on pull requests that touch Markdown (`--offline`, internal links, `fail: true` so it gates the PR), keeping `workflow_dispatch` for a manual full external-URL sweep. The `issues: write` permission and `peter-evans/create-issue-from-file` step are gone — a PR failure is the signal, not an unowned issue.
- **security.yml** — weekly cron removed. `npm audit` already runs on every PR. The heavy OWASP Dependency Check and the licence report (whose PR gate already exists as `npm run lint:licenses` in ci.yml) are now gated on `workflow_dispatch` instead of `schedule`, so they stay runnable on demand without dead-code gating.
- **test/workflows.test.js** — the guards that pinned the old scheduled layout are inverted: no workflow may have a `schedule:`/`- cron:` trigger, no job may gate on `github.event_name == 'schedule'`, the link check must gate PRs, and the manual jobs must remain dispatchable. The no-cron guard was mutation-tested: reintroducing a cron line makes it fail.

## Verification

- `grep -rn 'cron:' .github/` returns nothing
- All four workflows parse as YAML; actionlint reports nothing on the changed files
- Local offline lychee run over all Markdown: 0 errors
- Full local gate green under Node 22: eslint, prettier, stylelint, markdownlint, jscpd, licences, build, 272/272 tests

## Note on main

Scheduled workflows fire from the default branch, so the weekly timers on `main` keep firing until this reaches `main` via the next release — which is queued right after this merge.