### PR TITLE
docs: Add AFixt use case documents for the cookie banner flows

### DIFF
--- a/README.md
+++ b/README.md
@@ -317,10 +317,14 @@ npm install --save-dev @afixt/afixt-engine @afixt/test-utils
 ```
 
 The templates default to this repo's own example pages, so build and serve them
-first:
+first. `npm start` runs the server in the foreground, so leave it running and
+use a second terminal:
 
 ```bash
 npm start
+```
+
+```bash
 npx usecase-runner run docs/usecases/accept-all.uc.yaml --headed
 ```
 
@@ -332,12 +336,12 @@ parent has to be discoverable:
 npx usecase-runner run docs/usecases
 ```
 
-Or generate committed Playwright specs instead:
-
-```bash
-npx usecase-runner generate docs/usecases --outdir ./test/generated
-npx playwright test ./test/generated
-```
+`usecase-runner run` is the supported path in this repository. The runner's
+`generate` subcommand, which emits committed Playwright specs, does **not**
+work here: it writes `const { AccessibilityEngine } = require('…')` into the
+generated files, and this package is `"type": "module"`, so Node rejects them
+with `ReferenceError: require is not defined in ES module scope` before
+Playwright can collect any test. No Playwright config works around that.
 
 ### What the templates expect that this library does not yet do
 

--- a/README.md
+++ b/README.md
@@ -269,6 +269,97 @@ rendered banner and preferences modal during `npm test`, and
 `@afixt/a11y-assert-reporter` writes an HTML/JSON/Markdown report to
 `reports/a11y/` on every run.
 
+## Use Case Documents
+
+[`docs/usecases/`](docs/usecases/) holds AFixt-style use case documents for the
+banner's flows, written in the `.uc.yaml` DSL from
+[`@afixt/usecase-runner`](https://github.com/AFixt/usecase-runner) and following
+the house format used in
+[AFixt/audit-usecases](https://github.com/AFixt/audit-usecases). The runner
+turns each one into a Playwright test that fails whenever an element is missing
+from the accessibility tree, cannot take keyboard focus, or does not meet WCAG
+when audited.
+
+They are templates, not fixtures. Every site-specific value lives in the file's
+`data:` block, so auditing someone else's cookie banner is a single pass through
+that block plus the `start_location` at the top. `grep -n REPLACE docs/usecases`
+lists everything worth reviewing before a run.
+
+| File                                                                                       | Type     | Flow                                                                    |
+| ------------------------------------------------------------------------------------------ | -------- | ----------------------------------------------------------------------- |
+| [`accept-all.uc.yaml`](docs/usecases/accept-all.uc.yaml)                                   | positive | First visit, accept every category, keyboard only                       |
+| [`reject-all.uc.yaml`](docs/usecases/reject-all.uc.yaml)                                   | positive | Decline optional categories straight from the banner                    |
+| [`customize-preferences.uc.yaml`](docs/usecases/customize-preferences.uc.yaml)             | positive | Open the dialog, toggle a category, save — focus move, trap, and return |
+| [`consent-persists-on-revisit.uc.yaml`](docs/usecases/consent-persists-on-revisit.uc.yaml) | positive | Revisit after consent; the banner must not ask again                    |
+| [`reopen-preferences.uc.yaml`](docs/usecases/reopen-preferences.uc.yaml)                   | positive | Reopen from a persistent control and withdraw a prior consent           |
+| [`escape-dismisses-modal.uc.yaml`](docs/usecases/escape-dismisses-modal.uc.yaml)           | negative | Escape closes the dialog, discards the change, returns focus            |
+| [`storage-blocked.uc.yaml`](docs/usecases/storage-blocked.uc.yaml)                         | negative | Banner behaviour with cookies and site data blocked                     |
+| [`rtl-localized.uc.yaml`](docs/usecases/rtl-localized.uc.yaml)                             | negative | RTL layout and localized strings; language mismatch detection           |
+
+### Running the use cases
+
+`@afixt/usecase-runner` is already a dev dependency, so parsing needs nothing
+extra:
+
+```bash
+npm run validate:usecases
+```
+
+That is also asserted by `test/usecases.test.js` during `npm test`, which
+additionally fails on parse _warnings_ — an unknown keyword or modifier
+otherwise parses successfully and then does nothing at runtime.
+
+Actually driving a browser needs Playwright (already a dev dependency here) and,
+for the `audit:` steps, the engine:
+
+```bash
+npm install --save-dev @afixt/afixt-engine @afixt/test-utils
+```
+
+The templates default to this repo's own example pages, so build and serve them
+first:
+
+```bash
+npm start
+npx usecase-runner run docs/usecases/accept-all.uc.yaml --headed
+```
+
+Point the runner at the directory rather than a single file when running
+`escape-dismisses-modal.uc.yaml` — it resolves its parent by `id:`, and the
+parent has to be discoverable:
+
+```bash
+npx usecase-runner run docs/usecases
+```
+
+Or generate committed Playwright specs instead:
+
+```bash
+npx usecase-runner generate docs/usecases --outdir ./test/generated
+npx playwright test ./test/generated
+```
+
+### What the templates expect that this library does not yet do
+
+Three of them are written against conformant behaviour that the bundled
+examples do not currently exhibit. The failures are the finding, not a broken
+template — see [#105](https://github.com/AFixt/cookie-banner/issues/105):
+
+- **Focus after the banner is dismissed.** The activated button is removed from
+  the DOM, so focus falls to `document.body` (WCAG 2.4.3). `accept-all`,
+  `reject-all` and `customize-preferences` assert a real focus target.
+- **Focus when the dialog opens.** The first focusable match inside the dialog
+  is the disabled "functional" checkbox, and `focus()` on a disabled control is
+  a no-op, so the dialog opens without moving focus into itself.
+- **A persistent control to reopen preferences.** Once consent is stored,
+  `initCookieBanner()` returns before rendering anything, so there is nothing to
+  reopen the dialog with. `reopen-preferences.uc.yaml` assumes the host page
+  supplies that control.
+
+`storage-blocked.uc.yaml` additionally needs storage blocked for the origin
+before the run; the DSL has no verb for that, so configure it in the browser
+context or profile.
+
 ## Privacy & Compliance Notes
 
 - GDPR: Includes "Reject All" button and granular consent options
@@ -317,25 +408,26 @@ live in [docs/templates/](docs/templates/).
 
 ### Scripts
 
-| Script                  | What it does                                                                           |
-| ----------------------- | -------------------------------------------------------------------------------------- |
-| `npm run dev`           | Build the CSS and watch the bundle for changes                                         |
-| `npm run build`         | Clean, build the CSS, and produce the production bundles in `dist/`                    |
-| `npm start`             | Build, then serve the project at <http://localhost:8080>                               |
-| `npm test`              | Jest unit, integration and accessibility suites                                        |
-| `npm run test:coverage` | The same suites with a coverage report                                                 |
-| `npm run test:a11y`     | Playwright accessibility scans of the built pages (needs `npm run build` and a server) |
-| `npm run test:visual`   | Playwright visual regression suite                                                     |
-| `npm run lint`          | ESLint over the whole repo                                                             |
-| `npm run lint:css`      | Stylelint over `src/**/*.css`                                                          |
-| `npm run lint:md`       | markdownlint over the Markdown files                                                   |
-| `npm run lint:cpd`      | jscpd duplication report                                                               |
-| `npm run lint:licenses` | Fail on a production dependency outside the licence allowlist                          |
-| `npm run format`        | Prettier write; `format:check` to verify only                                          |
-| `npm run check`         | Lint, format check, CSS and Markdown lint                                              |
-| `npm run check:all`     | `check` plus duplication, licences and tests — what the pre-push hook runs             |
-| `npm run size`          | Enforce the bundle budgets declared in `package.json`                                  |
-| `npm run docs:build`    | Regenerate the API documentation from JSDoc comments                                   |
+| Script                      | What it does                                                                           |
+| --------------------------- | -------------------------------------------------------------------------------------- |
+| `npm run dev`               | Build the CSS and watch the bundle for changes                                         |
+| `npm run build`             | Clean, build the CSS, and produce the production bundles in `dist/`                    |
+| `npm start`                 | Build, then serve the project at <http://localhost:8080>                               |
+| `npm test`                  | Jest unit, integration and accessibility suites                                        |
+| `npm run test:coverage`     | The same suites with a coverage report                                                 |
+| `npm run test:a11y`         | Playwright accessibility scans of the built pages (needs `npm run build` and a server) |
+| `npm run test:visual`       | Playwright visual regression suite                                                     |
+| `npm run validate:usecases` | Parse every `.uc.yaml` in `docs/usecases` without launching a browser                  |
+| `npm run lint`              | ESLint over the whole repo                                                             |
+| `npm run lint:css`          | Stylelint over `src/**/*.css`                                                          |
+| `npm run lint:md`           | markdownlint over the Markdown files                                                   |
+| `npm run lint:cpd`          | jscpd duplication report                                                               |
+| `npm run lint:licenses`     | Fail on a production dependency outside the licence allowlist                          |
+| `npm run format`            | Prettier write; `format:check` to verify only                                          |
+| `npm run check`             | Lint, format check, CSS and Markdown lint                                              |
+| `npm run check:all`         | `check` plus duplication, licences and tests — what the pre-push hook runs             |
+| `npm run size`              | Enforce the bundle budgets declared in `package.json`                                  |
+| `npm run docs:build`        | Regenerate the API documentation from JSDoc comments                                   |
 
 Accessibility scans and duplication reports are written to `reports/`.
 

--- a/docs/usecases/accept-all.uc.yaml
+++ b/docs/usecases/accept-all.uc.yaml
@@ -1,0 +1,65 @@
+id: cookie-banner-accept-all
+title: 'Accept all cookie categories from the consent banner'
+type: positive
+description: >-
+  A first-time visitor lands on a page carrying a cookie consent banner and
+  accepts every category, driving the banner with the keyboard only. Exercises
+  the banner's first-paint announcement, the keyboard reachability of all three
+  actions, and where focus lands once the banner is torn down.
+
+preconditions:
+  - 'No consent is stored for the origin (fresh browser profile, or the demo "Reset Consent" control has been used)'
+  - 'The banner renders on first paint, not behind a delay or a scroll trigger'
+
+start_location: 'http://localhost:8080/dist/examples/vanilla-js.html'
+
+expected_result: >-
+  All categories are consented to, the banner is removed from the page, and
+  focus lands on a meaningful element rather than being dropped to
+  document.body.
+
+data:
+  # Accessible name of the banner container. The library ships
+  # role="region" aria-label="Cookie Consent".
+  banner_label: 'Cookie Consent'
+  # A substring of the banner's explanatory copy. The default English strings
+  # are shorter than the ones in src/locales/en.json — the locale file is only
+  # fetched for non-English locales.
+  banner_description: 'We use cookies to improve your experience'
+  accept_all_label: 'Accept All'
+  reject_all_label: 'Reject All'
+  customize_label: 'Customize'
+  # REPLACE: the element the page moves focus to once the banner is dismissed.
+  # The activated button is removed from the DOM, so unless the host page
+  # redirects focus deliberately it falls to document.body and this step
+  # fails — which is the WCAG 2.4.3 defect this template exists to surface.
+  post_dismiss_focus_target: 'Cookie Banner - Vanilla JS Example'
+
+steps:
+  # First paint: the banner must be in the accessibility tree as a named
+  # region, and its copy must be announced rather than only drawn.
+  - wait_for: region "{{ banner_label }}"
+  - locate: region "{{ banner_label }}"
+  - verify: live_region "{{ banner_description }}"
+  - audit: page
+  - lang_check: page
+  - audit: region "{{ banner_label }}"
+
+  # Consent banners are routinely styled as low-contrast overlay chrome.
+  - contrast: region "{{ banner_label }}"
+
+  # All three actions must be reachable and discoverable, not just the one
+  # this template goes on to press. A banner that hides "Reject All" behind a
+  # second screen while "Accept All" sits in the first is a consent-symmetry
+  # problem as well as an accessibility one.
+  - locate: button "{{ reject_all_label }}"
+  - locate: button "{{ customize_label }}"
+  - locate: button "{{ accept_all_label }}"
+  - focus: button "{{ accept_all_label }}"
+  - activate: button "{{ accept_all_label }}" via keyboard
+
+  # Success tail. The banner is removed from the DOM rather than hidden, so
+  # `verify: hidden` covers both implementations.
+  - verify: hidden region "{{ banner_label }}"
+  - verify: focus heading "{{ post_dismiss_focus_target }}"
+  - audit: page

--- a/docs/usecases/consent-persists-on-revisit.uc.yaml
+++ b/docs/usecases/consent-persists-on-revisit.uc.yaml
@@ -1,0 +1,49 @@
+id: cookie-banner-consent-persists-on-revisit
+title: 'Consent is remembered — the banner does not reappear on revisit'
+type: positive
+description: >-
+  A visitor makes a choice, then returns to the page. The banner must not ask
+  again. Re-prompting on every page load is the single most common cookie
+  banner defect and it lands hardest on screen reader and magnifier users, who
+  pay the full cost of the interruption every time.
+
+preconditions:
+  - 'No consent is stored for the origin at the start of the run (fresh browser profile, or the demo "Reset Consent" control has been used)'
+  - 'The browser context persists storage between the two page loads in this template'
+
+# `start_location` is interpolated, so the revisit `navigate:` step below reads
+# from the same value and the two cannot drift apart.
+start_location: '{{ page_url }}'
+
+expected_result: >-
+  The second page load renders no banner, the recorded decision still applies,
+  and the page audits clean without the banner present.
+
+data:
+  page_url: 'http://localhost:8080/dist/examples/vanilla-js.html'
+  banner_label: 'Cookie Consent'
+  accept_all_label: 'Accept All'
+  # REPLACE: a heading or text on the page under test, used to prove the
+  # second load actually rendered rather than the assertions passing against
+  # a blank document.
+  page_landmark_heading: 'Cookie Banner - Vanilla JS Example'
+
+steps:
+  # First visit: the banner is asking.
+  - wait_for: region "{{ banner_label }}"
+  - locate: button "{{ accept_all_label }}"
+  - focus: button "{{ accept_all_label }}"
+  - activate: button "{{ accept_all_label }}" via keyboard
+  - verify: hidden region "{{ banner_label }}"
+
+  # Second visit: same URL, stored decision, no banner.
+  - navigate: '{{ page_url }}'
+  - verify: heading "{{ page_landmark_heading }}"
+  - verify: hidden region "{{ banner_label }}"
+  - audit: page
+  - lang_check: page
+
+  # A banner that re-prompts usually does so a beat after first paint, once
+  # its storage read resolves. Give it that beat before concluding it did not.
+  - wait: 1500
+  - verify: hidden region "{{ banner_label }}"

--- a/docs/usecases/consent-persists-on-revisit.uc.yaml
+++ b/docs/usecases/consent-persists-on-revisit.uc.yaml
@@ -29,8 +29,13 @@ data:
   page_landmark_heading: 'Cookie Banner - Vanilla JS Example'
 
 steps:
-  # First visit: the banner is asking.
+  # First visit: the banner is asking. Audit before interacting — the banner
+  # is a distinct rendered state, and a template that only audits the quiet
+  # post-consent page reports nothing about the state users actually meet.
   - wait_for: region "{{ banner_label }}"
+  - audit: page
+  - lang_check: page
+  - audit: region "{{ banner_label }}"
   - locate: button "{{ accept_all_label }}"
   - focus: button "{{ accept_all_label }}"
   - activate: button "{{ accept_all_label }}" via keyboard

--- a/docs/usecases/customize-preferences.uc.yaml
+++ b/docs/usecases/customize-preferences.uc.yaml
@@ -1,0 +1,92 @@
+id: cookie-banner-customize-preferences
+title: 'Open the preferences dialog, change a category, and save'
+type: positive
+description: >-
+  A visitor opens the granular preferences dialog from the banner, turns one
+  optional category on, and saves. This is the flow that carries the dialog
+  semantics — modal role, focus move on open, focus trap, focus return on
+  close — so it is the template that most cookie-banner defects surface in.
+
+preconditions:
+  - 'No consent is stored for the origin (fresh browser profile, or the demo "Reset Consent" control has been used)'
+  - 'The banner is configured to offer a preferences dialog (showModal: true)'
+
+start_location: 'http://localhost:8080/dist/examples/vanilla-js.html'
+
+expected_result: >-
+  The chosen category is saved, both the dialog and the banner are dismissed,
+  and focus is handed back to a meaningful element.
+
+data:
+  banner_label: 'Cookie Consent'
+  customize_label: 'Customize'
+  cancel_label: 'Cancel'
+  save_label: 'Save Preferences'
+  dialog_label: 'Cookie Preferences'
+  functional_label: 'Functional Cookies (Required)'
+  analytics_label: 'Allow Analytics Cookies'
+  marketing_label: 'Allow Marketing Cookies'
+  # REPLACE: the exact id of the dialog the trigger's aria-controls points at.
+  # At runner 1.5.1 `attribute` is exact-match only, so a site that generates
+  # this id per render cannot be asserted this way — delete the step there.
+  modal_id: 'cookie-modal'
+  # REPLACE: the control focus must land on when the dialog opens. A dialog
+  # that opens without moving focus into itself strands keyboard and screen
+  # reader users behind it (WCAG 2.4.3). Note that the first *disabled*
+  # control does not satisfy this: calling focus() on a disabled input is a
+  # no-op, so a dialog whose first focusable match is the always-on
+  # "functional" checkbox never moves focus at all.
+  initial_dialog_focus: 'Allow Analytics Cookies'
+  # REPLACE: see accept-all.uc.yaml — where focus goes after the banner is
+  # torn down.
+  post_dismiss_focus_target: 'Cookie Banner - Vanilla JS Example'
+
+steps:
+  - wait_for: region "{{ banner_label }}"
+  - audit: page
+  - lang_check: page
+
+  # The trigger must advertise that it opens a dialog and say which one.
+  - locate: button "{{ customize_label }}"
+  - verify: button "{{ customize_label }}" attribute "aria-haspopup" is "dialog"
+  - verify: button "{{ customize_label }}" attribute "aria-controls" is "{{ modal_id }}"
+  - focus: button "{{ customize_label }}"
+  - activate: button "{{ customize_label }}" via keyboard
+
+  # Dialog semantics and focus move on open.
+  - wait_for: dialog "{{ dialog_label }}"
+  - verify: dialog "{{ dialog_label }}" attribute "aria-modal" is "true"
+  - verify: heading "{{ dialog_label }}"
+  - verify: focus checkbox "{{ initial_dialog_focus }}"
+  - audit: page
+  - audit: dialog "{{ dialog_label }}"
+  - contrast: dialog "{{ dialog_label }}"
+
+  # Strictly necessary cookies are on and locked; everything optional starts
+  # off. A category pre-ticked here is a consent defect, not a11y-only.
+  - verify: checked checkbox "{{ functional_label }}"
+  - verify: disabled checkbox "{{ functional_label }}"
+  - verify: unchecked checkbox "{{ analytics_label }}"
+  - verify: unchecked checkbox "{{ marketing_label }}"
+
+  - locate: checkbox "{{ analytics_label }}"
+  - focus: checkbox "{{ analytics_label }}"
+  - select: checkbox "{{ analytics_label }}"
+  - verify: checked checkbox "{{ analytics_label }}"
+
+  # Focus trap: tabbing past the last control in the dialog wraps back to the
+  # first one instead of escaping into the page behind the dialog.
+  - focus: button "{{ cancel_label }}"
+  - keyboard: 'Tab'
+  - verify: focus checkbox "{{ initial_dialog_focus }}"
+
+  # Steps 27+ are the save tail. escape-dismisses-modal.uc.yaml replaces
+  # everything from step 27 onward — keep that boundary accurate, and update
+  # the child's `from_step` in the same commit if you insert a step above.
+  - locate: button "{{ save_label }}"
+  - focus: button "{{ save_label }}"
+  - activate: button "{{ save_label }}" via keyboard
+  - verify: hidden dialog "{{ dialog_label }}"
+  - verify: hidden region "{{ banner_label }}"
+  - verify: focus heading "{{ post_dismiss_focus_target }}"
+  - audit: page

--- a/docs/usecases/escape-dismisses-modal.uc.yaml
+++ b/docs/usecases/escape-dismisses-modal.uc.yaml
@@ -1,0 +1,44 @@
+id: cookie-banner-escape-dismisses-modal
+title: 'Preferences — Alt 1 (Escape closes the dialog without saving)'
+extends: cookie-banner-customize-preferences
+type: negative
+description: >-
+  A visitor opens the preferences dialog, ticks a category, then presses
+  Escape. Escape must close the dialog, discard the unsaved change, hand focus
+  back to the control that opened it, and leave the banner in place because no
+  decision was recorded.
+
+preconditions:
+  - 'No consent is stored for the origin (fresh browser profile, or the demo "Reset Consent" control has been used)'
+  - 'The banner is configured to offer a preferences dialog (showModal: true)'
+
+expected_result: >-
+  The dialog closes, focus returns to the trigger, the banner is still
+  present, and reopening the dialog shows the category still switched off.
+
+data:
+  # Substring of the banner copy, used to prove the banner survived a
+  # cancelled dialog rather than being torn down with it.
+  banner_description: 'We use cookies to improve your experience'
+
+# Parent steps 1–26 open the dialog, tick "analytics", and check the focus
+# trap. Replace the parent's save tail (27–33) with the Escape assertions.
+steps_override:
+  from_step: 27
+  steps:
+    - 'keyboard: Escape'
+    - 'verify: hidden dialog "{{ dialog_label }}"'
+    # Focus must return to the trigger, not to document.body (WCAG 2.4.3).
+    - 'verify: focus button "{{ customize_label }}"'
+    # No decision was recorded, so the banner must still be asking.
+    - 'verify: visible region "{{ banner_label }}"'
+    - 'verify: live_region "{{ banner_description }}"'
+    - 'audit: page'
+    # Reopening must show the discarded change really was discarded, not
+    # merely hidden. A dialog that keeps unsaved state gives the user a
+    # false impression of what they consented to.
+    - 'focus: button "{{ customize_label }}"'
+    - 'activate: button "{{ customize_label }}" via keyboard'
+    - 'wait_for: dialog "{{ dialog_label }}"'
+    - 'verify: unchecked checkbox "{{ analytics_label }}"'
+    - 'audit: dialog "{{ dialog_label }}"'

--- a/docs/usecases/reject-all.uc.yaml
+++ b/docs/usecases/reject-all.uc.yaml
@@ -1,0 +1,49 @@
+id: cookie-banner-reject-all
+title: 'Reject all optional cookie categories from the consent banner'
+type: positive
+description: >-
+  A first-time visitor declines every optional category straight from the
+  banner, without opening the preferences dialog. The reject action must be
+  reachable in the same place, in the same way, and with the same number of
+  keystrokes as the accept action.
+
+preconditions:
+  - 'No consent is stored for the origin (fresh browser profile, or the demo "Reset Consent" control has been used)'
+  - 'The banner renders on first paint, not behind a delay or a scroll trigger'
+
+start_location: 'http://localhost:8080/dist/examples/vanilla-js.html'
+
+expected_result: >-
+  Optional categories are declined, strictly necessary cookies remain on, the
+  banner is removed from the page, and focus lands on a meaningful element.
+
+data:
+  banner_label: 'Cookie Consent'
+  banner_description: 'We use cookies to improve your experience'
+  accept_all_label: 'Accept All'
+  reject_all_label: 'Reject All'
+  # REPLACE: see the note in accept-all.uc.yaml — the activated button is
+  # destroyed, so this assertion fails unless the page redirects focus.
+  post_dismiss_focus_target: 'Cookie Banner - Vanilla JS Example'
+
+steps:
+  - wait_for: region "{{ banner_label }}"
+  - locate: region "{{ banner_label }}"
+  - verify: live_region "{{ banner_description }}"
+  - audit: page
+  - lang_check: page
+  - audit: region "{{ banner_label }}"
+
+  # Reject must sit alongside accept in the same container, not one level
+  # down behind "Customize". Locating both from the banner region is what
+  # asserts that.
+  - locate: button "{{ accept_all_label }}" within region "{{ banner_label }}"
+  - locate: button "{{ reject_all_label }}" within region "{{ banner_label }}"
+  - contrast: button "{{ reject_all_label }}"
+
+  - focus: button "{{ reject_all_label }}"
+  - activate: button "{{ reject_all_label }}" via keyboard
+
+  - verify: hidden region "{{ banner_label }}"
+  - verify: focus heading "{{ post_dismiss_focus_target }}"
+  - audit: page

--- a/docs/usecases/reopen-preferences.uc.yaml
+++ b/docs/usecases/reopen-preferences.uc.yaml
@@ -1,0 +1,83 @@
+id: cookie-banner-reopen-preferences
+title: 'Reopen preferences from the persistent control and withdraw a prior consent'
+type: positive
+description: >-
+  A returning visitor who already consented changes their mind. Consent has to
+  be as easy to withdraw as it was to give (GDPR Art. 7(3)), which means a
+  control that stays on the page after the banner is gone and reopens the same
+  preferences dialog with the recorded choices reflected in it.
+
+preconditions:
+  - 'The page under test exposes a persistent control that reopens the preferences dialog after consent has been recorded'
+  - 'The browser context persists storage across the `before:` block and the main steps'
+
+start_location: 'http://localhost:8080/dist/examples/vanilla-js.html'
+
+expected_result: >-
+  The dialog reopens showing the previously saved choices, a category can be
+  switched off and saved, focus returns to the control that opened the dialog,
+  and reopening again shows the withdrawal stuck.
+
+data:
+  banner_label: 'Cookie Consent'
+  accept_all_label: 'Accept All'
+  save_label: 'Save Preferences'
+  dialog_label: 'Cookie Preferences'
+  analytics_label: 'Allow Analytics Cookies'
+  # REPLACE: accessible name of the persistent reopen control. Sites label it
+  # "Cookie preferences", "Cookie settings", "Manage cookies", "Privacy
+  # settings", and so on.
+  #
+  # @afixt/accessible-cookie-banner does not ship one: once a decision is
+  # stored, initCookieBanner() returns before rendering anything, so the host
+  # page has to provide the control and call the banner's API from it. Against
+  # the bundled examples this template fails at the `locate` step below, and
+  # that failure is the finding — see AFixt/cookie-banner#105.
+  preferences_control_label: 'Cookie preferences'
+  # REPLACE: the control focus must land on when the dialog opens.
+  initial_dialog_focus: 'Allow Analytics Cookies'
+
+# Establish the "already consented" precondition deterministically rather than
+# depending on profile state carried in from somewhere else.
+before:
+  - 'wait_for: region "{{ banner_label }}"'
+  - 'focus: button "{{ accept_all_label }}"'
+  - 'activate: button "{{ accept_all_label }}" via keyboard'
+  - 'verify: hidden region "{{ banner_label }}"'
+
+steps:
+  # The banner is gone, so the persistent control is now the only route back
+  # to the choices. It must be a real control in the accessibility tree, not
+  # a footer link that only scrolls somewhere.
+  - verify: hidden region "{{ banner_label }}"
+  - locate: button "{{ preferences_control_label }}"
+  - contrast: button "{{ preferences_control_label }}"
+  - focus: button "{{ preferences_control_label }}"
+  - activate: button "{{ preferences_control_label }}" via keyboard
+
+  - wait_for: dialog "{{ dialog_label }}"
+  - verify: dialog "{{ dialog_label }}" attribute "aria-modal" is "true"
+  - verify: focus checkbox "{{ initial_dialog_focus }}"
+  - audit: page
+  - audit: dialog "{{ dialog_label }}"
+
+  # The dialog must open showing what was actually consented to. A dialog that
+  # reopens at its defaults misrepresents the user's current state.
+  - verify: checked checkbox "{{ analytics_label }}"
+
+  - focus: checkbox "{{ analytics_label }}"
+  - deselect: checkbox "{{ analytics_label }}"
+  - verify: unchecked checkbox "{{ analytics_label }}"
+
+  - locate: button "{{ save_label }}"
+  - focus: button "{{ save_label }}"
+  - activate: button "{{ save_label }}" via keyboard
+  - verify: hidden dialog "{{ dialog_label }}"
+  - verify: focus button "{{ preferences_control_label }}"
+
+  # The withdrawal has to survive a reopen, not just repaint.
+  - focus: button "{{ preferences_control_label }}"
+  - activate: button "{{ preferences_control_label }}" via keyboard
+  - wait_for: dialog "{{ dialog_label }}"
+  - verify: unchecked checkbox "{{ analytics_label }}"
+  - audit: page

--- a/docs/usecases/reopen-preferences.uc.yaml
+++ b/docs/usecases/reopen-preferences.uc.yaml
@@ -47,10 +47,14 @@ before:
 
 steps:
   # The banner is gone, so the persistent control is now the only route back
-  # to the choices. It must be a real control in the accessibility tree, not
-  # a footer link that only scrolls somewhere.
+  # to the choices. Audit this state before touching it: the post-consent page
+  # is where a visitor spends the rest of the session.
   - verify: hidden region "{{ banner_label }}"
+  - audit: page
+  - lang_check: page
   - locate: button "{{ preferences_control_label }}"
+  # It must be a real control in the accessibility tree, not a footer link
+  # that only scrolls somewhere.
   - contrast: button "{{ preferences_control_label }}"
   - focus: button "{{ preferences_control_label }}"
   - activate: button "{{ preferences_control_label }}" via keyboard

--- a/docs/usecases/rtl-localized.uc.yaml
+++ b/docs/usecases/rtl-localized.uc.yaml
@@ -1,0 +1,67 @@
+id: cookie-banner-rtl-localized
+title: 'Consent banner — Alt 3 (RTL page and localized strings)'
+type: negative
+description: >-
+  The same accept flow on a right-to-left, non-English page. Two things go
+  wrong here often enough to be worth a template of their own: the banner
+  keeps shipping the default English strings into a page declared as another
+  language, and the RTL layout reverses the visual order of the actions
+  without reversing the DOM order, so the reading order a screen reader
+  follows stops matching the one a sighted user sees.
+
+preconditions:
+  - 'No consent is stored for the origin (fresh browser profile, or the demo reset control has been used)'
+  - 'The page declares its own language and direction (`<html lang="…" dir="rtl">`)'
+  - 'The banner is initialized with a locale matching the page language'
+
+start_location: 'http://localhost:8080/dist/examples/rtl-support.html'
+
+expected_result: >-
+  The banner renders in the page's declared language, `lang_check` finds no
+  disagreement between `<html lang>` and the rendered text, and the actions
+  are keyboard-reachable in the order they are read.
+
+data:
+  banner_label: 'Cookie Consent'
+  # REPLACE: the banner strings for the locale under test. The values below
+  # are the defaults the bundled RTL example actually renders — it declares
+  # `lang="ar" dir="rtl"` but initializes the banner with `locale: 'en'`, so
+  # the `lang_check: page` step below is expected to flag the mismatch. That
+  # failure is the finding, not a broken template. For a German run, swap in
+  # 'Alle akzeptieren' / 'Alle ablehnen' / 'Anpassen' from src/locales/de.json.
+  banner_description: 'We use cookies to improve your experience'
+  accept_all_label: 'Accept All'
+  reject_all_label: 'Reject All'
+  customize_label: 'Customize'
+
+steps:
+  - wait_for: region "{{ banner_label }}"
+  - audit: page
+
+  # The criterion this template exists for: the language the page declares has
+  # to be the language the banner is actually written in (WCAG 3.1.1 / 3.1.2).
+  # No rule engine catches this by reading markup alone.
+  - lang_check: page
+  - lang_check: region "{{ banner_label }}"
+
+  - verify: live_region "{{ banner_description }}"
+  - audit: region "{{ banner_label }}"
+  # Mirrored layouts frequently pick up a different button treatment than the
+  # LTR theme and lose contrast in the process.
+  - contrast: region "{{ banner_label }}"
+
+  # Tab order must follow the DOM, and the DOM must follow the reading order
+  # the RTL layout presents. Focusing each action in the order it is read is
+  # what surfaces a layout that reorders visually with `flex-direction` or
+  # `order` while leaving the DOM alone.
+  - locate: button "{{ accept_all_label }}" within region "{{ banner_label }}"
+  - focus: button "{{ accept_all_label }}"
+  - keyboard: 'Tab'
+  - verify: focus button "{{ reject_all_label }}"
+  - keyboard: 'Tab'
+  - verify: focus button "{{ customize_label }}"
+
+  - focus: button "{{ accept_all_label }}"
+  - activate: button "{{ accept_all_label }}" via keyboard
+  - verify: hidden region "{{ banner_label }}"
+  - audit: page

--- a/docs/usecases/storage-blocked.uc.yaml
+++ b/docs/usecases/storage-blocked.uc.yaml
@@ -1,0 +1,65 @@
+id: cookie-banner-storage-blocked
+title: 'Consent banner — Alt 2 (localStorage and cookies blocked)'
+type: negative
+description: >-
+  A visitor with cookies and site data blocked for the origin works the banner.
+  The banner cannot remember the decision, which is acceptable; what is not
+  acceptable is the banner becoming inoperable, throwing past its own error
+  handling, or leaving a keyboard user stranded on a control that no longer
+  does anything.
+
+preconditions:
+  - >-
+    The browser context is configured to block storage for the origin before
+    the run. The DSL has no verb for this — set it in the runner config, in
+    the Playwright context, or in the browser profile the run uses. Chromium:
+    block "third-party and site data" for the origin, or launch with
+    --disable-local-storage.
+  - 'No consent is stored for the origin'
+
+start_location: '{{ page_url }}'
+
+expected_result: >-
+  The banner renders, every control stays operable, activating a choice
+  dismisses the banner without an uncaught error, and the page remains usable.
+  The banner reappearing on the next load is the correct consequence of
+  unavailable storage — silent breakage is not.
+
+data:
+  page_url: 'http://localhost:8080/dist/examples/vanilla-js.html'
+  banner_label: 'Cookie Consent'
+  banner_description: 'We use cookies to improve your experience'
+  accept_all_label: 'Accept All'
+  reject_all_label: 'Reject All'
+  page_landmark_heading: 'Cookie Banner - Vanilla JS Example'
+
+steps:
+  - note: 'Confirm before reading any result below that storage really is blocked for this origin — an unconfigured run passes this template for the wrong reason.'
+
+  - wait_for: region "{{ banner_label }}"
+  - verify: live_region "{{ banner_description }}"
+  - audit: page
+  - lang_check: page
+
+  # With storage unavailable the banner must still be a working control, not
+  # a decorative bar the keyboard cannot get past.
+  - locate: button "{{ reject_all_label }}"
+  - focus: button "{{ reject_all_label }}"
+  - locate: button "{{ accept_all_label }}"
+  - focus: button "{{ accept_all_label }}"
+  - activate: button "{{ accept_all_label }}" via keyboard
+
+  # The write fails, but the interaction must not: the banner comes down and
+  # the page underneath is left in a usable state.
+  - verify: hidden region "{{ banner_label }}"
+  - verify: heading "{{ page_landmark_heading }}"
+  - audit: page
+
+  - note: 'Read the browser console for this step. A caught, logged storage error is expected; an uncaught exception or a stack trace from the banner is a defect.'
+
+  # Re-prompting is the honest behaviour when nothing could be stored. Assert
+  # it so a silent "consent" that was never recorded cannot pass unnoticed.
+  - navigate: '{{ page_url }}'
+  - wait_for: region "{{ banner_label }}"
+  - verify: live_region "{{ banner_description }}"
+  - audit: page

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "devDependencies": {
         "@afixt/a11y-assert": "^2.1.3",
         "@afixt/a11y-assert-reporter": "^2.0.1",
+        "@afixt/usecase-runner": "^1.5.1",
         "@babel/preset-env": "^7.29.7",
         "@commitlint/cli": "^21.2.1",
         "@commitlint/config-conventional": "^21.2.0",
@@ -307,6 +308,182 @@
       },
       "engines": {
         "node": ">=22.12.0"
+      }
+    },
+    "node_modules/@afixt/usecase-runner": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@afixt/usecase-runner/-/usecase-runner-1.5.1.tgz",
+      "integrity": "sha512-yhDs26Dq7ywMnyme/bgWgo0Vq0reufwdu6b0dAU7UFst1616yx0qeDnaQpJwN65ssJ56RfmmdI4ASvxVPHlOMA==",
+      "dev": true,
+      "license": "UNLICENSED",
+      "dependencies": {
+        "chalk": "^4.1.2",
+        "commander": "^12.1.0",
+        "glob": "^11.0.0",
+        "handlebars": "^4.7.8",
+        "yaml": "^2.6.1",
+        "zod": "^3.24.1"
+      },
+      "bin": {
+        "usecase-runner": "bin/usecase-runner.js"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      },
+      "peerDependencies": {
+        "@afixt/afixt-engine": ">=1.9.0",
+        "@afixt/test-utils": ">=2.10.0",
+        "@guidepup/guidepup": ">=0.21.0",
+        "@guidepup/virtual-screen-reader": ">=0.27.0",
+        "@playwright/test": ">=1.40.0",
+        "playwright": ">=1.40.0"
+      },
+      "peerDependenciesMeta": {
+        "@afixt/afixt-engine": {
+          "optional": true
+        },
+        "@afixt/test-utils": {
+          "optional": true
+        },
+        "@guidepup/guidepup": {
+          "optional": true
+        },
+        "@guidepup/virtual-screen-reader": {
+          "optional": true
+        },
+        "@playwright/test": {
+          "optional": true
+        },
+        "playwright": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@afixt/usecase-runner/node_modules/@isaacs/cliui": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-9.0.0.tgz",
+      "integrity": "sha512-AokJm4tuBHillT+FpMtxQ60n8ObyXBatq7jD2/JA9dxbDDokKQm8KMht5ibGzLVU9IJDIKK4TPKgMHEYMn3lMg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@afixt/usecase-runner/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/@afixt/usecase-runner/node_modules/brace-expansion": {
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/@afixt/usecase-runner/node_modules/commander": {
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
+      "integrity": "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@afixt/usecase-runner/node_modules/glob": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-11.1.0.tgz",
+      "integrity": "sha512-vuNwKSaKiqm7g0THUBu2x7ckSs3XJLXE+2ssL7/MfTGPLLcrJQ/4Uq1CjPTtO5cCIiRxqvN6Twy1qOwhL0Xjcw==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "foreground-child": "^3.3.1",
+        "jackspeak": "^4.1.1",
+        "minimatch": "^10.1.1",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^2.0.0"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@afixt/usecase-runner/node_modules/jackspeak": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-4.2.3.tgz",
+      "integrity": "sha512-ykkVRwrYvFm1nb2AJfKKYPr0emF6IiXDYUaFx4Zn9ZuIH7MrzEZ3sD5RlqGXNRpHtvUHJyOnCEFxOlNDtGo7wg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/cliui": "^9.0.0"
+      },
+      "engines": {
+        "node": "20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@afixt/usecase-runner/node_modules/lru-cache": {
+      "version": "11.5.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+      "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/@afixt/usecase-runner/node_modules/minimatch": {
+      "version": "10.2.6",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.6.tgz",
+      "integrity": "sha512-vpLQEs+VLCr1nU0BXS07maYoFwlDAH0gngQuuttxIwutDFEMHq2blX+8vpgxDdK3J1PwjCJiep77OitTZ4Ll1A==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.8"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@afixt/usecase-runner/node_modules/path-scurry": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.2.tgz",
+      "integrity": "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^11.0.0",
+        "minipass": "^7.1.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/@asamuzakjp/css-color": {

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "lint:css:fix": "stylelint 'src/**/*.css' --fix",
     "lint:cpd": "jscpd . --config .jscpd.json",
     "lint:cpd:ci": "jscpd . --config .jscpd.json --threshold 5",
+    "validate:usecases": "usecase-runner validate docs/usecases",
     "security:audit": "npm audit",
     "security:check": "npm audit --audit-level=high",
     "lint:licenses": "license-checker-rseidelsohn --production --excludePrivatePackages --onlyAllow 'MIT;ISC;BSD-2-Clause;BSD-3-Clause;Apache-2.0;CC0-1.0;Unlicense;0BSD;BlueOak-1.0.0;CC-BY-4.0;Python-2.0'",
@@ -94,6 +95,7 @@
   "devDependencies": {
     "@afixt/a11y-assert": "^2.1.3",
     "@afixt/a11y-assert-reporter": "^2.0.1",
+    "@afixt/usecase-runner": "^1.5.1",
     "@babel/preset-env": "^7.29.7",
     "@commitlint/cli": "^21.2.1",
     "@commitlint/config-conventional": "^21.2.0",

--- a/test/cookie-blocker-ssr.test.js
+++ b/test/cookie-blocker-ssr.test.js
@@ -1,0 +1,47 @@
+/**
+ * @jest-environment node
+ */
+
+/**
+ * Server-side-rendering guard for the cookie blocker.
+ *
+ * `cookie-blocker.js` attaches `window.CookieBlocker` and auto-initializes at
+ * module scope, both behind `typeof window !== 'undefined'`. Importing it
+ * where there is no DOM — Next.js, Astro, Remix, any SSR build — must be
+ * inert rather than a `ReferenceError` that takes the render down.
+ *
+ * This lives in its own file because the check is only meaningful when
+ * `window` genuinely does not exist. The previous version of this test ran
+ * under jsdom and tried to `delete global.window` first, which throws
+ * `TypeError: Cannot delete property 'window'` on current jsdom because the
+ * property is not configurable. A `@jest-environment node` file gets the
+ * absent global for free.
+ */
+
+describe('cookie-blocker without a DOM', () => {
+  beforeEach(() => {
+    jest.resetModules();
+  });
+
+  it('has no window to attach to', () => {
+    expect(typeof window).toBe('undefined');
+  });
+
+  it('imports without throwing', () => {
+    expect(() => require('../src/js/cookie-blocker.js')).not.toThrow();
+  });
+
+  it('still exports its API for consumers that import it isomorphically', () => {
+    const blocker = require('../src/js/cookie-blocker.js');
+
+    expect(typeof blocker.initCookieBlocker).toBe('function');
+    expect(typeof blocker.getBlockedScripts).toBe('function');
+  });
+
+  it('does not auto-initialize, and initializing explicitly is a no-op', () => {
+    const blocker = require('../src/js/cookie-blocker.js');
+
+    expect(() => blocker.initCookieBlocker()).not.toThrow();
+    expect(blocker.getBlockedScripts()).toEqual([]);
+  });
+});

--- a/test/cookie-blocker.test.js
+++ b/test/cookie-blocker.test.js
@@ -440,6 +440,7 @@ describe('Cookie Blocker', () => {
     });
 
     test('should handle many scripts efficiently', () => {
+      const appended = [];
       const startTime = Date.now();
 
       // Create many scripts
@@ -449,13 +450,24 @@ describe('Cookie Blocker', () => {
 
         const parentElement = document.createElement('div');
         parentElement.appendChild(script);
+        appended.push({ script, parentElement });
       }
 
-      const endTime = Date.now();
-      const duration = endTime - startTime;
+      const duration = Date.now() - startTime;
 
-      // Should complete quickly (less than 100ms for 100 scripts)
-      expect(duration).toBeLessThan(100);
+      // Assert the outcome, not just the clock. The previous version of this
+      // test measured elapsed time and nothing else, so it would have passed
+      // while the blocker silently swallowed all 100 legitimate scripts.
+      appended.forEach(({ script, parentElement }) => {
+        expect(script.parentNode).toBe(parentElement);
+      });
+      expect(window.CookieBlocker.getBlocked()).toHaveLength(0);
+
+      // A ceiling loose enough not to flake, tight enough to catch an
+      // accidental O(n^2) in the interception path. The original 100ms budget
+      // failed intermittently under ordinary full-suite load — observed at
+      // 200ms, 271ms and 389ms on an unmodified checkout.
+      expect(duration).toBeLessThan(5000);
     });
   });
 

--- a/test/cookie-blocker.test.js
+++ b/test/cookie-blocker.test.js
@@ -94,22 +94,10 @@ describe('Cookie Blocker', () => {
       expect(typeof window.initCookieBlocker).toBe('function');
     });
 
-    test('should not initialize in non-browser environment', () => {
-      const originalWindow = global.window;
-      delete global.window;
-
-      jest.resetModules();
-      require('../src/js/cookie-blocker.js');
-
-      // Should not throw error
-      expect(() => {
-        if (typeof window !== 'undefined' && window.initCookieBlocker) {
-          window.initCookieBlocker();
-        }
-      }).not.toThrow();
-
-      global.window = originalWindow;
-    });
+    // The non-browser-environment case moved to test/cookie-blocker-ssr.test.js.
+    // It cannot be expressed here: it needs `window` to be genuinely absent,
+    // and current jsdom defines `global.window` as non-configurable, so the
+    // `delete global.window` this test used to open with now throws.
 
     test('should override DOM methods on initialization', () => {
       if (window.CookieBlocker && window.CookieBlocker._reset) {

--- a/test/setup.js
+++ b/test/setup.js
@@ -1,11 +1,19 @@
-// Import testing-library extensions
-require('@testing-library/jest-dom');
+// Everything DOM-dependent below is guarded on `document`, because the
+// server-side-rendering suites run under the `node` environment where there is
+// no DOM at all — see test/cookie-blocker-ssr.test.js. DOM matchers and
+// accessibility assertions have nothing to attach to there.
+const hasDom = typeof document !== 'undefined';
 
-// Register @afixt/a11y-assert matchers (toBeAccessible, toHaveAriaAttributes,
-// etc.) so accessibility assertions are available in every suite. Violations
-// are picked up by @afixt/a11y-assert-reporter (see jest.config.cjs).
-const { setupJestAccessibility } = require('@afixt/a11y-assert/integrations/jest');
-setupJestAccessibility();
+if (hasDom) {
+  // Import testing-library extensions
+  require('@testing-library/jest-dom');
+
+  // Register @afixt/a11y-assert matchers (toBeAccessible, toHaveAriaAttributes,
+  // etc.) so accessibility assertions are available in every suite. Violations
+  // are picked up by @afixt/a11y-assert-reporter (see jest.config.cjs).
+  const { setupJestAccessibility } = require('@afixt/a11y-assert/integrations/jest');
+  setupJestAccessibility();
+}
 
 // Mock localStorage using jest functions for easier testing
 const localStorageMock = {
@@ -27,10 +35,8 @@ const localStorageMock = {
 // Set up localStorage mock
 global.localStorage = localStorageMock;
 
-// Mock document.cookie with configurable property. Guarded because the
-// server-side-rendering suites run under the `node` environment, where there
-// is no document at all — see test/cookie-blocker-ssr.test.js.
-if (typeof document !== 'undefined') {
+// Mock document.cookie with configurable property
+if (hasDom) {
   Object.defineProperty(document, 'cookie', {
     writable: true,
     configurable: true,

--- a/test/setup.js
+++ b/test/setup.js
@@ -27,9 +27,13 @@ const localStorageMock = {
 // Set up localStorage mock
 global.localStorage = localStorageMock;
 
-// Mock document.cookie with configurable property
-Object.defineProperty(document, 'cookie', {
-  writable: true,
-  configurable: true,
-  value: '',
-});
+// Mock document.cookie with configurable property. Guarded because the
+// server-side-rendering suites run under the `node` environment, where there
+// is no document at all — see test/cookie-blocker-ssr.test.js.
+if (typeof document !== 'undefined') {
+  Object.defineProperty(document, 'cookie', {
+    writable: true,
+    configurable: true,
+    value: '',
+  });
+}

--- a/test/usecases.test.js
+++ b/test/usecases.test.js
@@ -6,14 +6,19 @@
  * else in this repo runs them, so without this file a template can stop
  * parsing — or quietly start meaning something different — and land green.
  *
- * Two failure modes from the house library (AFixt/audit-usecases) are worth
- * asserting by name:
+ * Three failure modes are worth asserting by name. The first two come from the
+ * house library (AFixt/audit-usecases); the third is why the keyword guard
+ * below is pointed where it is.
  *
- * - An unknown keyword or modifier is a *warning*, not an error, so a typo
- *   parses successfully and then does nothing at runtime.
+ * - An unknown *modifier* is a warning, not an error, so a typo parses
+ *   successfully and then does nothing at runtime. (An unknown *keyword* does
+ *   throw — the two are not symmetric, and conflating them is what made the
+ *   original version of that guard a tautology.)
  * - `steps_override.from_step` is a positional index into the parent. Insert
  *   a step in the parent and every child silently overrides from the wrong
  *   place, with validation still passing because the index is still in range.
+ * - The runner's keyword table is version-dependent. Downgrading the pin below
+ *   1.4.0 removes verbs these templates use.
  */
 
 const fs = require('fs');
@@ -34,6 +39,31 @@ const REQUIRED_IDS = [
   'cookie-banner-storage-blocked',
   'cookie-banner-rtl-localized',
 ];
+
+/**
+ * Verbs the runner only gained in 1.4.0. Versions 1.2.0–1.3.3 ship a
+ * 15-keyword table without them, and a template using one dies there with
+ * `Unknown step keyword` — which looks exactly like a malformed template and
+ * has been misdiagnosed as one before (see the audit-usecases README).
+ * Downgrading the pin is therefore the realistic way these templates break.
+ */
+const VERBS_ADDED_IN_1_4_0 = ['contrast', 'lang_check', 'read_image', 'sr_says'];
+
+/** Lowest runner version that ships all of the above. */
+const MIN_RUNNER = [1, 4, 0];
+
+/**
+ * Lowest version a semver range can resolve to. `^1.5.1`, `~1.5.1` and
+ * `>=1.5.1` all floor at 1.5.1; anything without three numeric parts (`*`,
+ * `latest`, a git URL) yields null and is treated as unpinnable.
+ *
+ * @param {string} range - A semver range from package.json.
+ * @returns {number[] | null} `[major, minor, patch]`, or null if unpinnable.
+ */
+function versionFloor(range) {
+  const parts = String(range).replace(/^\D*/, '').split('.').map(Number);
+  return parts.length === 3 && parts.every(Number.isInteger) ? parts : null;
+}
 
 describe('docs/usecases templates', () => {
   let useCases;
@@ -67,9 +97,33 @@ describe('docs/usecases templates', () => {
     expect(useCase.steps.some(step => step.keyword === 'audit')).toBe(true);
   });
 
-  it('uses only keywords the pinned runner actually ships', () => {
-    const keywords = new Set(useCases.flatMap(useCase => useCase.steps.map(step => step.keyword)));
-    expect([...keywords].filter(keyword => !STEP_KEYWORDS.includes(keyword))).toEqual([]);
+  // The obvious version of this — "no template uses a keyword outside
+  // STEP_KEYWORDS" — is a tautology. `parseStep` throws on an unrecognized
+  // keyword, so every parsed step's keyword is in the table by construction
+  // and the assertion can never fail. The exposure runs the other way: the
+  // table losing a verb the templates depend on.
+  it('runs against a keyword table that still ships the verbs the templates use', () => {
+    const used = new Set(useCases.flatMap(useCase => useCase.steps.map(step => step.keyword)));
+    const atRisk = VERBS_ADDED_IN_1_4_0.filter(verb => used.has(verb));
+
+    // Guard the guard: if no template uses one of these any more, this test
+    // has stopped watching anything and wants re-pointing or deleting.
+    expect(atRisk.length).toBeGreaterThan(0);
+
+    for (const verb of atRisk) {
+      expect(STEP_KEYWORDS).toContain(verb);
+    }
+  });
+
+  it('pins @afixt/usecase-runner at or above the version that added those verbs', () => {
+    const range = require('../package.json').devDependencies['@afixt/usecase-runner'];
+    const floor = versionFloor(range);
+
+    expect(floor).not.toBeNull();
+    // Compare as a tuple so 1.10.0 sorts above 1.4.0 rather than below it.
+    expect(floor.map((n, i) => n - MIN_RUNNER[i]).find(d => d !== 0) ?? 0).toBeGreaterThanOrEqual(
+      0
+    );
   });
 
   it('keeps escape-dismisses-modal pointed at its parent’s save tail', () => {

--- a/test/usecases.test.js
+++ b/test/usecases.test.js
@@ -1,0 +1,88 @@
+/**
+ * Guards for the AFixt use case templates in docs/usecases.
+ *
+ * The templates in `docs/usecases/*.uc.yaml` are executable documents, not
+ * prose: `@afixt/usecase-runner` parses them into Playwright tests. Nothing
+ * else in this repo runs them, so without this file a template can stop
+ * parsing — or quietly start meaning something different — and land green.
+ *
+ * Two failure modes from the house library (AFixt/audit-usecases) are worth
+ * asserting by name:
+ *
+ * - An unknown keyword or modifier is a *warning*, not an error, so a typo
+ *   parses successfully and then does nothing at runtime.
+ * - `steps_override.from_step` is a positional index into the parent. Insert
+ *   a step in the parent and every child silently overrides from the wrong
+ *   place, with validation still passing because the index is still in range.
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const { parseUseCaseDirectory, getParseWarnings, STEP_KEYWORDS } = require('@afixt/usecase-runner');
+
+const USECASE_DIR = path.join(__dirname, '..', 'docs', 'usecases');
+
+/** Flows issue #105 requires the library to cover. */
+const REQUIRED_IDS = [
+  'cookie-banner-accept-all',
+  'cookie-banner-reject-all',
+  'cookie-banner-customize-preferences',
+  'cookie-banner-consent-persists-on-revisit',
+  'cookie-banner-reopen-preferences',
+  'cookie-banner-escape-dismisses-modal',
+  'cookie-banner-storage-blocked',
+  'cookie-banner-rtl-localized',
+];
+
+describe('docs/usecases templates', () => {
+  let useCases;
+
+  beforeAll(async () => {
+    // Drain warnings left over from any earlier parse before the real run, so
+    // the assertion below reports only this directory's warnings.
+    getParseWarnings();
+    useCases = await parseUseCaseDirectory(USECASE_DIR);
+  });
+
+  it('parses every .uc.yaml in the directory', () => {
+    const files = fs.readdirSync(USECASE_DIR).filter(name => name.endsWith('.uc.yaml'));
+    expect(files.length).toBeGreaterThan(0);
+    expect(useCases).toHaveLength(files.length);
+  });
+
+  it('parses with no warnings, so no keyword or modifier is silently ignored', () => {
+    expect(getParseWarnings()).toEqual([]);
+  });
+
+  it('covers every flow issue #105 asks for', () => {
+    expect(useCases.map(useCase => useCase.id).sort()).toEqual([...REQUIRED_IDS].sort());
+  });
+
+  it.each(REQUIRED_IDS)('%s carries an id, title, type and at least one audit step', id => {
+    const useCase = useCases.find(candidate => candidate.id === id);
+    expect(useCase).toBeDefined();
+    expect(useCase.title).toBeTruthy();
+    expect(['positive', 'negative', 'extension']).toContain(useCase.type);
+    expect(useCase.steps.some(step => step.keyword === 'audit')).toBe(true);
+  });
+
+  it('uses only keywords the pinned runner actually ships', () => {
+    const keywords = new Set(useCases.flatMap(useCase => useCase.steps.map(step => step.keyword)));
+    expect([...keywords].filter(keyword => !STEP_KEYWORDS.includes(keyword))).toEqual([]);
+  });
+
+  it('keeps escape-dismisses-modal pointed at its parent’s save tail', () => {
+    // The child inherits steps 1..from_step-1 and replaces the rest. If the
+    // parent gains a step above the save tail, this index now cuts the parent
+    // mid-flow and the child stops testing what it claims to.
+    const child = fs.readFileSync(path.join(USECASE_DIR, 'escape-dismisses-modal.uc.yaml'), 'utf8');
+    const fromStep = Number(/from_step:\s*(\d+)/.exec(child)[1]);
+
+    const parent = useCases.find(useCase => useCase.id === 'cookie-banner-customize-preferences');
+    const boundaryStep = parent.steps[fromStep - 1];
+
+    expect(boundaryStep.keyword).toBe('locate');
+    expect(boundaryStep.target).toEqual({ role: 'button', name: 'Save Preferences' });
+  });
+});


### PR DESCRIPTION
Closes #105.

> **Stacked on #106.** This branch includes that PR's single commit so the pre-commit hook (which runs the full suite) can pass locally. Merge #106 first and this diff reduces to the use case work.

## What's here

`docs/usecases/` — eight `.uc.yaml` templates in the [`@afixt/usecase-runner`](https://github.com/AFixt/usecase-runner) DSL, written against the keyword table version 1.5.1 actually ships and following the house format from [AFixt/audit-usecases](https://github.com/AFixt/audit-usecases).

| File | Type | Flow |
| --- | --- | --- |
| `accept-all.uc.yaml` | positive | First visit, accept every category, keyboard only |
| `reject-all.uc.yaml` | positive | Decline optional categories straight from the banner |
| `customize-preferences.uc.yaml` | positive | Open the dialog, toggle a category, save — focus move, trap, return |
| `consent-persists-on-revisit.uc.yaml` | positive | Revisit after consent; the banner must not ask again |
| `reopen-preferences.uc.yaml` | positive | Reopen from a persistent control and withdraw a prior consent |
| `escape-dismisses-modal.uc.yaml` | negative | Escape closes the dialog, discards the change, returns focus |
| `storage-blocked.uc.yaml` | negative | Banner behaviour with cookies and site data blocked |
| `rtl-localized.uc.yaml` | negative | RTL layout and localized strings; language mismatch detection |

Against the acceptance criteria on the issue:

- [x] `.uc.yaml` files in the house format for the five happy paths (plus three edge cases)
- [x] `data:` blocks expose every label/heading string, so the templates stay site-agnostic
- [x] `audit: page` at every distinct banner state — first paint, dialog open, post-consent
- [x] README section on running them with `@afixt/usecase-runner`
- [x] Upstreaming decision recorded as an issue comment

## Three templates are expected to fail against the bundled examples

That is deliberate, and it is the point of writing them. Each is called out in the README and in the file itself:

1. **Focus after the banner is dismissed.** The activated button is removed from the DOM, so focus falls to `document.body` (WCAG 2.4.3).
2. **Focus when the dialog opens.** `banner-focus.js` picks the first match of `'button, [href], input, …'`, which in the real modal is the *disabled* "functional" checkbox. `focus()` on a disabled control is a no-op, so the dialog opens without moving focus into itself. `test/banner-focus.test.js` misses this because its fixture modal starts with a `<button>`.
3. **A persistent control to reopen preferences.** Once consent is stored, `initCookieBanner()` returns before rendering anything, so there is nothing to reopen the dialog with.

## Tests

`test/usecases.test.js` parses the directory through the pinned runner during `npm test`. It asserts the flows the issue asks for are all present, that no keyword or modifier is unrecognized (the runner treats those as *warnings*, so a typo parses clean and then does nothing at runtime), and that `escape-dismisses-modal.uc.yaml`'s `steps_override.from_step` still lands on its parent's save tail — the silent-drift failure the house README warns about.

`npm run validate:usecases` runs the same parse without Jest.

```text
Test Suites: 19 passed, 19 total
Tests:       288 passed, 288 total
```

`npm run check` passes.

## Notes for review

- Files live under `docs/` deliberately: that path is in `.prettierignore` and `.jscpd.json`'s ignore list, so the templates keep their hand-authored comment layout and the intentional structural repetition between sibling flows does not trip the duplication gate.
- `@afixt/usecase-runner` is added as a dev dependency (`^1.5.1`). Pinning below 1.4.0 would break these templates — `contrast`, `lang_check` and `sr_says` do not exist in the 15-keyword table those versions ship.