### PR TITLE
docs: Record the no-scheduled-Actions policy in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -75,6 +75,24 @@ Releases are managed with `standard-version`. The changelog is automatically gen
 - `npm run release:major` - Force major release (X.0.0)
 - `npm run release:dry-run` - Preview release without changes
 
+## GitHub Actions
+
+**No regularly scheduled GitHub Action may ever be added to this repository.**
+No `on.schedule:` block, no `- cron:` entry, in any workflow, on any branch.
+
+A timer-triggered check reports a problem hours or days after it entered the
+codebase, against no particular author, and is routinely ignored. The same
+check on a pull request gates the defect at the point of introduction, where
+the failure is attributable to the change that caused it. Any check worth
+running belongs in the PR pipeline.
+
+`workflow_dispatch` (manual runs) remains allowed — a manual trigger is not a
+schedule. Use it for the heavy sweeps that are too slow to gate every PR.
+
+`test/workflows.test.js` enforces this, so a reintroduced schedule fails
+`npm test` rather than being discovered later. See
+[#103](https://github.com/AFixt/cookie-banner/issues/103).
+
 ## Build/Lint/Test Commands
 
 - Node.js version: LTS (use `nvm use` or Node.js 22+)

--- a/test/cookie-blocker-ssr.test.js
+++ b/test/cookie-blocker-ssr.test.js
@@ -1,0 +1,47 @@
+/**
+ * @jest-environment node
+ */
+
+/**
+ * Server-side-rendering guard for the cookie blocker.
+ *
+ * `cookie-blocker.js` attaches `window.CookieBlocker` and auto-initializes at
+ * module scope, both behind `typeof window !== 'undefined'`. Importing it
+ * where there is no DOM — Next.js, Astro, Remix, any SSR build — must be
+ * inert rather than a `ReferenceError` that takes the render down.
+ *
+ * This lives in its own file because the check is only meaningful when
+ * `window` genuinely does not exist. The previous version of this test ran
+ * under jsdom and tried to `delete global.window` first, which throws
+ * `TypeError: Cannot delete property 'window'` on current jsdom because the
+ * property is not configurable. A `@jest-environment node` file gets the
+ * absent global for free.
+ */
+
+describe('cookie-blocker without a DOM', () => {
+  beforeEach(() => {
+    jest.resetModules();
+  });
+
+  it('has no window to attach to', () => {
+    expect(typeof window).toBe('undefined');
+  });
+
+  it('imports without throwing', () => {
+    expect(() => require('../src/js/cookie-blocker.js')).not.toThrow();
+  });
+
+  it('still exports its API for consumers that import it isomorphically', () => {
+    const blocker = require('../src/js/cookie-blocker.js');
+
+    expect(typeof blocker.initCookieBlocker).toBe('function');
+    expect(typeof blocker.getBlockedScripts).toBe('function');
+  });
+
+  it('does not auto-initialize, and initializing explicitly is a no-op', () => {
+    const blocker = require('../src/js/cookie-blocker.js');
+
+    expect(() => blocker.initCookieBlocker()).not.toThrow();
+    expect(blocker.getBlockedScripts()).toEqual([]);
+  });
+});

--- a/test/cookie-blocker.test.js
+++ b/test/cookie-blocker.test.js
@@ -440,6 +440,7 @@ describe('Cookie Blocker', () => {
     });
 
     test('should handle many scripts efficiently', () => {
+      const appended = [];
       const startTime = Date.now();
 
       // Create many scripts
@@ -449,13 +450,24 @@ describe('Cookie Blocker', () => {
 
         const parentElement = document.createElement('div');
         parentElement.appendChild(script);
+        appended.push({ script, parentElement });
       }
 
-      const endTime = Date.now();
-      const duration = endTime - startTime;
+      const duration = Date.now() - startTime;
 
-      // Should complete quickly (less than 100ms for 100 scripts)
-      expect(duration).toBeLessThan(100);
+      // Assert the outcome, not just the clock. The previous version of this
+      // test measured elapsed time and nothing else, so it would have passed
+      // while the blocker silently swallowed all 100 legitimate scripts.
+      appended.forEach(({ script, parentElement }) => {
+        expect(script.parentNode).toBe(parentElement);
+      });
+      expect(window.CookieBlocker.getBlocked()).toHaveLength(0);
+
+      // A ceiling loose enough not to flake, tight enough to catch an
+      // accidental O(n^2) in the interception path. The original 100ms budget
+      // failed intermittently under ordinary full-suite load — observed at
+      // 200ms, 271ms and 389ms on an unmodified checkout.
+      expect(duration).toBeLessThan(5000);
     });
   });
 

--- a/test/cookie-blocker.test.js
+++ b/test/cookie-blocker.test.js
@@ -94,22 +94,10 @@ describe('Cookie Blocker', () => {
       expect(typeof window.initCookieBlocker).toBe('function');
     });
 
-    test('should not initialize in non-browser environment', () => {
-      const originalWindow = global.window;
-      delete global.window;
-
-      jest.resetModules();
-      require('../src/js/cookie-blocker.js');
-
-      // Should not throw error
-      expect(() => {
-        if (typeof window !== 'undefined' && window.initCookieBlocker) {
-          window.initCookieBlocker();
-        }
-      }).not.toThrow();
-
-      global.window = originalWindow;
-    });
+    // The non-browser-environment case moved to test/cookie-blocker-ssr.test.js.
+    // It cannot be expressed here: it needs `window` to be genuinely absent,
+    // and current jsdom defines `global.window` as non-configurable, so the
+    // `delete global.window` this test used to open with now throws.
 
     test('should override DOM methods on initialization', () => {
       if (window.CookieBlocker && window.CookieBlocker._reset) {

--- a/test/setup.js
+++ b/test/setup.js
@@ -1,11 +1,19 @@
-// Import testing-library extensions
-require('@testing-library/jest-dom');
+// Everything DOM-dependent below is guarded on `document`, because the
+// server-side-rendering suites run under the `node` environment where there is
+// no DOM at all — see test/cookie-blocker-ssr.test.js. DOM matchers and
+// accessibility assertions have nothing to attach to there.
+const hasDom = typeof document !== 'undefined';
 
-// Register @afixt/a11y-assert matchers (toBeAccessible, toHaveAriaAttributes,
-// etc.) so accessibility assertions are available in every suite. Violations
-// are picked up by @afixt/a11y-assert-reporter (see jest.config.cjs).
-const { setupJestAccessibility } = require('@afixt/a11y-assert/integrations/jest');
-setupJestAccessibility();
+if (hasDom) {
+  // Import testing-library extensions
+  require('@testing-library/jest-dom');
+
+  // Register @afixt/a11y-assert matchers (toBeAccessible, toHaveAriaAttributes,
+  // etc.) so accessibility assertions are available in every suite. Violations
+  // are picked up by @afixt/a11y-assert-reporter (see jest.config.cjs).
+  const { setupJestAccessibility } = require('@afixt/a11y-assert/integrations/jest');
+  setupJestAccessibility();
+}
 
 // Mock localStorage using jest functions for easier testing
 const localStorageMock = {
@@ -27,10 +35,8 @@ const localStorageMock = {
 // Set up localStorage mock
 global.localStorage = localStorageMock;
 
-// Mock document.cookie with configurable property. Guarded because the
-// server-side-rendering suites run under the `node` environment, where there
-// is no document at all — see test/cookie-blocker-ssr.test.js.
-if (typeof document !== 'undefined') {
+// Mock document.cookie with configurable property
+if (hasDom) {
   Object.defineProperty(document, 'cookie', {
     writable: true,
     configurable: true,

--- a/test/setup.js
+++ b/test/setup.js
@@ -27,9 +27,13 @@ const localStorageMock = {
 // Set up localStorage mock
 global.localStorage = localStorageMock;
 
-// Mock document.cookie with configurable property
-Object.defineProperty(document, 'cookie', {
-  writable: true,
-  configurable: true,
-  value: '',
-});
+// Mock document.cookie with configurable property. Guarded because the
+// server-side-rendering suites run under the `node` environment, where there
+// is no document at all — see test/cookie-blocker-ssr.test.js.
+if (typeof document !== 'undefined') {
+  Object.defineProperty(document, 'cookie', {
+    writable: true,
+    configurable: true,
+    value: '',
+  });
+}


### PR DESCRIPTION
Completes the last outstanding item on #103.

> **Stacked on #106.** This branch includes that PR's single commit so the pre-commit hook (which runs the full suite) can pass locally. Merge #106 first and this diff reduces to the CLAUDE.md change.

## Why

#103 removed every cron trigger — done in #104 — and its Policy section states that CLAUDE.md carries the standing rule that none may be added back. The workflows changed; the rule was never written down.

That left `test/workflows.test.js` as the only place the policy existed. A test explains a constraint *after* someone trips it. CLAUDE.md explains it before.

## What's recorded

- No `on.schedule:` / `- cron:` in any workflow, on any branch, ever
- Why a PR-time check beats a timer: the failure is attributable to the change that caused it
- `workflow_dispatch` is still allowed — a manual trigger is not a schedule
- A pointer to `test/workflows.test.js` as the enforcement

## Status of #103's checklist

Verified on `develop`:

- `grep -rn 'cron:' .github/` returns nothing
- `ci.yml` runs on push + PR; `release.yml` on push to main; `link-check.yml` and `security.yml` on PR + `workflow_dispatch`
- The dormant `security.yml` schedule that lived only on `develop` is gone
- `main` still carries the old `link-check.yml` cron; that clears when `develop` next merges to `main`