### PR TITLE
chore(release): v1.3.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@afixt/accessible-cookie-banner",
-  "version": "1.2.1",
+  "version": "1.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@afixt/accessible-cookie-banner",
-      "version": "1.2.1",
+      "version": "1.3.0",
       "license": "MIT",
       "devDependencies": {
         "@afixt/a11y-assert": "^2.1.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@afixt/accessible-cookie-banner",
-  "version": "1.2.1",
+  "version": "1.3.0",
   "description": "A customizable, WCAG-conformant cookie consent banner with GDPR, CCPA compliance",
   "type": "module",
   "main": "dist/consent.js",


### PR DESCRIPTION
Version bump only — `package.json` + `package-lock.json`, 1.2.1 → **1.3.0**.

## Why minor

Two `feat` commits in `v1.2.1..develop`, no breaking changes:

- `feat(a11y): Add browser-level accessibility scans of the built bundle`
- `feat(a11y): Integrate @afixt/a11y-assert-reporter for structured test results`

## Note on the changelog

No CHANGELOG entry is generated here. `CHANGELOG.md` is `commit-and-tag-version` output and its newest entry is **1.1.1** — 1.2.0 and 1.2.1 are already missing, so this release is consistent with the two before it rather than introducing the gap. Worth fixing separately; regenerating it mid-release would rewrite history for versions already shipped.