### PR TITLE
Guard every workflow against silenced gates, not just ci.yml

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -37,6 +37,13 @@ jobs:
           # from the organisation-level NPM_TOKEN secret — see CLAUDE.md.
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
+      # Non-blocking, and that is a deliberate exception rather than an
+      # oversight: 10 high-severity advisories are already present on the
+      # default branch, all of them dev-dependency-only, so making this
+      # blocking today would fail every run for reasons unrelated to the
+      # change under test. It is allowlisted by name in
+      # test/workflows.test.js so it cannot be forgotten, and tracked in #109
+      # along with the dependency triage that would let the flag come off.
       - name: Run npm audit
         run: npm audit --audit-level=high
         continue-on-error: true

--- a/test/workflows.test.js
+++ b/test/workflows.test.js
@@ -124,7 +124,6 @@ describe('ci.yml', () => {
     expect(contents).toMatch(pattern);
   });
 
-
   it('never installs dependencies with --ignore-scripts', () => {
     expect(contents).not.toMatch(/--ignore-scripts/);
   });

--- a/test/workflows.test.js
+++ b/test/workflows.test.js
@@ -40,6 +40,64 @@ describe('GitHub Actions layout', () => {
   });
 });
 
+/**
+ * Every step permitted to report a failure as a success, and why.
+ *
+ * Keyed by workflow file, valued by the `name:` of the step. A silenced gate
+ * catches nothing, so each one has to be argued for here rather than added
+ * quietly in YAML.
+ */
+const PERMITTED_SILENCED_STEPS = {
+  // Baselines are captured on macOS and re-render differently on Linux.
+  'ci.yml': ['Run visual regression tests'],
+  // 10 high-severity advisories already present on the default branch, all
+  // dev-dependency-only. Blocking today would fail every run for reasons
+  // unrelated to the change under test. Tracked in #109 with the dependency
+  // triage that would let the flag come off.
+  'security.yml': ['Run npm audit'],
+};
+
+describe('no workflow silences its own gates', () => {
+  /*
+   * Scoped to `ci.yml` until #109. The identical defect was sitting in
+   * `security.yml` at the time — `npm audit` marked `continue-on-error: true`,
+   * reporting green while the command it runs exited non-zero — and this guard
+   * could not see it, because it read one file. #62 removed the pattern from
+   * `ci.yml`; nothing stopped it reappearing anywhere else.
+   *
+   * Reading the directory rather than a list also means a fifth workflow is
+   * covered the day it is added.
+   */
+  const workflowFiles = fs
+    .readdirSync(WORKFLOW_DIR)
+    .filter(name => /\.ya?ml$/.test(name))
+    .sort();
+
+  it('finds workflows to check at all — a vacuous guard is not a guard', () => {
+    expect(workflowFiles.length).toBeGreaterThan(0);
+  });
+
+  it.each(workflowFiles)('%s silences only the steps argued for here', name => {
+    const contents = workflow(name);
+    const permitted = PERMITTED_SILENCED_STEPS[name] || [];
+
+    const silenced = contents
+      .split('\n')
+      .filter(line => /^\s*continue-on-error:\s*true\s*$/.test(line));
+    expect(silenced).toHaveLength(permitted.length);
+
+    // Named, not just counted: swapping which step carries the flag would
+    // otherwise keep the count right and the meaning wrong.
+    for (const step of permitted) {
+      const from = contents.indexOf(`name: ${step}`);
+      expect(from).toBeGreaterThan(-1);
+      const nextStep = contents.indexOf('\n      - name:', from + 1);
+      const block = contents.slice(from, nextStep === -1 ? undefined : nextStep);
+      expect(block).toMatch(/continue-on-error: true/);
+    }
+  });
+});
+
 describe('ci.yml', () => {
   let contents;
 
@@ -66,15 +124,6 @@ describe('ci.yml', () => {
     expect(contents).toMatch(pattern);
   });
 
-  it('does not silence the quality gates', () => {
-    // The visual regression suite is the sole permitted exception: its
-    // baselines are captured on macOS and re-render differently on Linux.
-    const silenced = contents.split('\n').filter(line => /^\s*continue-on-error:/.test(line));
-    expect(silenced).toHaveLength(1);
-
-    const visualStep = contents.slice(contents.indexOf('Run visual regression tests'));
-    expect(visualStep).toMatch(/continue-on-error: true/);
-  });
 
   it('never installs dependencies with --ignore-scripts', () => {
     expect(contents).not.toMatch(/--ignore-scripts/);


### PR DESCRIPTION
Fixes #109 — **item 2 only**. Items 1 and 3 are deliberately left out; see the end.

## The class defect

`does not silence the quality gates` already asserts this exact property, but it lives inside `describe('ci.yml')` and reads one file. So `security.yml` silencing `npm audit` was invisible to the guard written to catch precisely that. #62 removed the pattern from `ci.yml`; nothing stopped it coming back somewhere else.

The guard now walks the workflow directory — a fifth workflow is covered the day it is added — and checks each file against a named allowlist:

```js
const PERMITTED_SILENCED_STEPS = {
  'ci.yml': ['Run visual regression tests'],   // macOS-captured baselines
  'security.yml': ['Run npm audit'],           // see below, tracked in #109
};
```

**Named, not counted.** Moving the flag from the visual-regression step to another step in the same file keeps the count at one and the meaning wrong. That now fails.

## What I did about the audit flag, and what I did not

It stays non-blocking. The 10 advisories are pre-existing and dev-dependency-only, so making it blocking today would fail every run for reasons unrelated to the change under test — you say as much in the issue.

What changes is that it is no longer invisible. It is an argued entry in the allowlist, and `security.yml` carries a comment giving the reason and pointing at #109. A silenced gate now has to be defended in a file someone reviews, instead of being one line of YAML nobody re-reads. That is the "explicit allowlist/exception with a tracking note" the issue asks for rather than the blanket silencer.

**Item 1** — whether `npm audit --audit-level=high` should block — is a maintainer call and I have not made it. One option worth considering when you do: since every advisory is dev-only, a blocking `npm audit --omit=dev --audit-level=high` would be green today and would genuinely gate anything reaching consumers, with the current full-tree run kept alongside for visibility. Happy to open that as a follow-up if you want it.

**Item 3** — the `@afixt/a11y-assert` → `puppeteer` bump that would clear several at once — is a dependency change, separate PR.

## Verification, and a caveat

I could not run `npm test` locally: `npm ci` 404s on `@afixt/test-utils` without the organisation `NPM_TOKEN`, exactly as the comment in `security.yml` describes. So I ran the assertions in `test/workflows.test.js` directly instead of through jest. **28 pass, 0 fail.** CI will be the real check, and it is worth you confirming the run is green rather than taking my word for the harness.

Non-vacuity, both directions:

- `continue-on-error: true` added to `link-check.yml` — a file the old guard never read — **fails** (`27 passed, 1 failed`).
- `ci.yml`'s existing flag moved from the visual step to `Run tests with coverage`, leaving the count at one — **fails**.

Removing both mutations returns it to 28 green.