### PR TITLE
test(ci): guard every workflow against silenced gates, not just ci.yml

### DIFF
--- a/test/workflows.test.js
+++ b/test/workflows.test.js
@@ -38,6 +38,63 @@ describe('GitHub Actions layout', () => {
     const files = fs.readdirSync(WORKFLOW_DIR).filter(name => /\.ya?ml$/.test(name));
     expect(files.sort()).toEqual(['ci.yml', 'link-check.yml', 'release.yml', 'security.yml']);
   });
+
+  /**
+   * Every `continue-on-error` permitted anywhere in `.github/workflows`, each
+   * with the reason it is allowed. A silenced gate reports failure as success,
+   * so each one is enumerated here rather than judged case by case.
+   *
+   * To add an entry you have to state why. To remove one, delete the line and
+   * the `continue-on-error` it describes.
+   */
+  const PERMITTED_SILENCED_STEPS = [
+    {
+      file: 'ci.yml',
+      step: 'Run visual regression tests',
+      // Baselines are captured on macOS and re-render differently on Linux.
+      reason: 'platform-dependent baselines',
+    },
+    {
+      file: 'security.yml',
+      step: 'Run npm audit',
+      // TRACKED EXCEPTION -- issue #109. `npm audit --audit-level=high` exits
+      // non-zero on 13 pre-existing high advisories, all reached through dev
+      // dependencies. `npm audit fix` resolves none of them: the bulk arrive
+      // via @afixt/a11y-assert 2.x -> @afixt/afixt-engine 1.x -> puppeteer ->
+      // extract-zip, which needs a11y-assert >= 3 (it depends on engine ^5).
+      // Remove this entry, and the continue-on-error it covers, once that bump
+      // lands -- do not let it become permanent by inattention.
+      reason: 'pre-existing advisories, tracked in #109',
+    },
+  ];
+
+  it('silences no workflow step that is not an enumerated exception', () => {
+    const found = [];
+
+    for (const file of fs.readdirSync(WORKFLOW_DIR).filter(name => /\.ya?ml$/.test(name))) {
+      const lines = workflow(file).split('\n');
+
+      lines.forEach((line, index) => {
+        // Only a real key counts; the word also appears in explanatory comments.
+        if (!/^\s*continue-on-error:\s*true\s*$/.test(line)) return;
+
+        // Attribute it to the nearest preceding `- name:` so the exception list
+        // names steps rather than line numbers, which move.
+        let step = '(unnamed step)';
+        for (let i = index; i >= 0; i -= 1) {
+          const match = /^\s*-?\s*name:\s*(.+?)\s*$/.exec(lines[i]);
+          if (match) {
+            step = match[1].replace(/^['"]|['"]$/g, '');
+            break;
+          }
+        }
+        found.push(`${file}: ${step}`);
+      });
+    }
+
+    const permitted = PERMITTED_SILENCED_STEPS.map(entry => `${entry.file}: ${entry.step}`);
+    expect(found.sort()).toEqual(permitted.sort());
+  });
 });
 
 describe('ci.yml', () => {


### PR DESCRIPTION
Refs #109 — this delivers part 2 of that issue's suggested fix, and turns part 1 from a judgement call into a decision with evidence. It does **not** close #109; see below.

## What this changes

`does not silence the quality gates` lived inside `describe('ci.yml')` and read only `ci.yml`. The same defect in any other workflow was unguarded — which is exactly how `security.yml`'s npm audit step kept `continue-on-error: true` and reported green.

Replaced with a check over **every** file in `.github/workflows`, comparing what it finds against an explicit list of permitted exceptions. Each entry names the step that carries it and says why it is allowed:

| Workflow | Step | Why permitted |
| --- | --- | --- |
| `ci.yml` | Run visual regression tests | macOS-captured baselines re-render on Linux |
| `security.yml` | Run npm audit | tracked exception, #109 |

Exceptions are attributed to the nearest preceding `- name:` rather than to line numbers, which move.

### Verification

Silenced a step in `link-check.yml` — a file the previous guard never read — and confirmed the check fails and names it:

```
✕ silences no workflow step that is not an enumerated exception
    + Received  + 1
    +   "link-check.yml: Checkout code",
```

Restored, green again. Full suite: **276 passed**, 19 suites.

## Why npm audit is still not blocking

Part 1 of the issue asks whether `npm audit --audit-level=high` should block, and notes that if the pre-existing highs make that impractical, that is a real answer — but it should be a tracked exception rather than a blanket silencer. That is what this PR implements, because I checked and **the advisories cannot be cleared today**:

- `npm audit --audit-level=high` currently exits non-zero on **13 high** advisories (up from the 10 in the issue).
- **`npm audit fix` resolves none of them.** Run with `--package-lock-only`, it leaves the lockfile byte-identical and the count unchanged. Even the five that report `fixAvailable: in-range` (`brace-expansion`, `fast-uri`, `ip-address`, `js-yaml`, `nanoid`) do not move.
- The rest report `fixAvailable: false` and all arrive through one chain:

```
@afixt/a11y-assert@2.1.3
└── @afixt/afixt-engine@1.11.5
    └── puppeteer@24.43.1 → @puppeteer/browsers → extract-zip
```

The fix is a dependency bump, not an audit flag: **`@afixt/a11y-assert` 3.1.0 depends on `@afixt/afixt-engine` `^5.0.0`** (and `puppeteer >=22`), which is the version line where the extract-zip exposure was dealt with in `a11y-mcp`. `@afixt/usecase-runner` is likewise pinned here at `^1.5.1` against a published 2.0.2 — and bumping it is what AFixt/cookie-banner#117 needs anyway, so the two want doing together.

I could not perform that bump: `@afixt/*` are private and this environment has no `NPM_TOKEN`, so `registry.npmjs.org` returns 404 for them and the upgraded tree cannot be installed or tested. Making the gate blocking without the bump would simply turn `security.yml` permanently red.

So the sequence is: bump `a11y-assert` to `^3.1.0` and `usecase-runner` to `^2.0.2` → re-run `npm audit` → drop `continue-on-error: true` from `security.yml` → delete the `security.yml` entry from `PERMITTED_SILENCED_STEPS`, at which point this guard starts enforcing it. The comment on that entry says so, so it cannot quietly become permanent.
