### PR TITLE
Block on advisories that reach production, keep the full tree for visibility

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -37,6 +37,13 @@ jobs:
           # from the organisation-level NPM_TOKEN secret — see CLAUDE.md.
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
+      # Non-blocking, and that is a deliberate exception rather than an
+      # oversight: 10 high-severity advisories are already present on the
+      # default branch, all of them dev-dependency-only, so making this
+      # blocking today would fail every run for reasons unrelated to the
+      # change under test. It is allowlisted by name in
+      # test/workflows.test.js so it cannot be forgotten, and tracked in #109
+      # along with the dependency triage that would let the flag come off.
       - name: Run npm audit
         run: npm audit --audit-level=high
         continue-on-error: true

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -37,13 +37,23 @@ jobs:
           # from the organisation-level NPM_TOKEN secret — see CLAUDE.md.
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
-      # Non-blocking, and that is a deliberate exception rather than an
-      # oversight: 10 high-severity advisories are already present on the
-      # default branch, all of them dev-dependency-only, so making this
-      # blocking today would fail every run for reasons unrelated to the
-      # change under test. It is allowlisted by name in
-      # test/workflows.test.js so it cannot be forgotten, and tracked in #109
-      # along with the dependency triage that would let the flag come off.
+      # What ships to consumers, and it blocks.
+      #
+      # Every advisory on the tree today is reached through devDependencies, so a
+      # production-scoped audit is green right now AND fails for real the day one
+      # lands in a shipped path. That is the half of #109's item 1 that can be
+      # answered without waiting on the dependency triage in item 3.
+      - name: Run npm audit (production dependencies)
+        run: npm audit --omit=dev --audit-level=high
+
+      # The full tree, non-blocking, for visibility.
+      #
+      # A deliberate exception rather than an oversight: 13 high-severity advisories
+      # are already present on the default branch, all dev-only, and `npm audit fix
+      # --package-lock-only` leaves the lockfile byte-identical — there is no
+      # in-range remedy to apply, so blocking here would fail every run for reasons
+      # no author can act on. Allowlisted by name in test/workflows.test.js so it
+      # cannot be forgotten, and tracked in #109 with the bump that would clear it.
       - name: Run npm audit
         run: npm audit --audit-level=high
         continue-on-error: true

--- a/test/workflows.test.js
+++ b/test/workflows.test.js
@@ -124,7 +124,6 @@ describe('ci.yml', () => {
     expect(contents).toMatch(pattern);
   });
 
-
   it('never installs dependencies with --ignore-scripts', () => {
     expect(contents).not.toMatch(/--ignore-scripts/);
   });

--- a/test/workflows.test.js
+++ b/test/workflows.test.js
@@ -40,6 +40,64 @@ describe('GitHub Actions layout', () => {
   });
 });
 
+/**
+ * Every step permitted to report a failure as a success, and why.
+ *
+ * Keyed by workflow file, valued by the `name:` of the step. A silenced gate
+ * catches nothing, so each one has to be argued for here rather than added
+ * quietly in YAML.
+ */
+const PERMITTED_SILENCED_STEPS = {
+  // Baselines are captured on macOS and re-render differently on Linux.
+  'ci.yml': ['Run visual regression tests'],
+  // 10 high-severity advisories already present on the default branch, all
+  // dev-dependency-only. Blocking today would fail every run for reasons
+  // unrelated to the change under test. Tracked in #109 with the dependency
+  // triage that would let the flag come off.
+  'security.yml': ['Run npm audit'],
+};
+
+describe('no workflow silences its own gates', () => {
+  /*
+   * Scoped to `ci.yml` until #109. The identical defect was sitting in
+   * `security.yml` at the time — `npm audit` marked `continue-on-error: true`,
+   * reporting green while the command it runs exited non-zero — and this guard
+   * could not see it, because it read one file. #62 removed the pattern from
+   * `ci.yml`; nothing stopped it reappearing anywhere else.
+   *
+   * Reading the directory rather than a list also means a fifth workflow is
+   * covered the day it is added.
+   */
+  const workflowFiles = fs
+    .readdirSync(WORKFLOW_DIR)
+    .filter(name => /\.ya?ml$/.test(name))
+    .sort();
+
+  it('finds workflows to check at all — a vacuous guard is not a guard', () => {
+    expect(workflowFiles.length).toBeGreaterThan(0);
+  });
+
+  it.each(workflowFiles)('%s silences only the steps argued for here', name => {
+    const contents = workflow(name);
+    const permitted = PERMITTED_SILENCED_STEPS[name] || [];
+
+    const silenced = contents
+      .split('\n')
+      .filter(line => /^\s*continue-on-error:\s*true\s*$/.test(line));
+    expect(silenced).toHaveLength(permitted.length);
+
+    // Named, not just counted: swapping which step carries the flag would
+    // otherwise keep the count right and the meaning wrong.
+    for (const step of permitted) {
+      const from = contents.indexOf(`name: ${step}`);
+      expect(from).toBeGreaterThan(-1);
+      const nextStep = contents.indexOf('\n      - name:', from + 1);
+      const block = contents.slice(from, nextStep === -1 ? undefined : nextStep);
+      expect(block).toMatch(/continue-on-error: true/);
+    }
+  });
+});
+
 describe('ci.yml', () => {
   let contents;
 
@@ -66,15 +124,6 @@ describe('ci.yml', () => {
     expect(contents).toMatch(pattern);
   });
 
-  it('does not silence the quality gates', () => {
-    // The visual regression suite is the sole permitted exception: its
-    // baselines are captured on macOS and re-render differently on Linux.
-    const silenced = contents.split('\n').filter(line => /^\s*continue-on-error:/.test(line));
-    expect(silenced).toHaveLength(1);
-
-    const visualStep = contents.slice(contents.indexOf('Run visual regression tests'));
-    expect(visualStep).toMatch(/continue-on-error: true/);
-  });
 
   it('never installs dependencies with --ignore-scripts', () => {
     expect(contents).not.toMatch(/--ignore-scripts/);

--- a/test/workflows.test.js
+++ b/test/workflows.test.js
@@ -88,8 +88,13 @@ describe('no workflow silences its own gates', () => {
 
     // Named, not just counted: swapping which step carries the flag would
     // otherwise keep the count right and the meaning wrong.
+    //
+    // The name is matched to end-of-line. Without that, an allowlisted `Run npm audit`
+    // also matches a `Run npm audit (production dependencies)` step declared above it,
+    // and the block that gets checked is the wrong one — which is how this guard first
+    // went red against a change that was correct.
     for (const step of permitted) {
-      const from = contents.indexOf(`name: ${step}`);
+      const from = contents.indexOf(`name: ${step}\n`);
       expect(from).toBeGreaterThan(-1);
       const nextStep = contents.indexOf('\n      - name:', from + 1);
       const block = contents.slice(from, nextStep === -1 ? undefined : nextStep);


### PR DESCRIPTION
Follow-up to #118, answering **item 1 of #109** — the half that no longer needs to wait on the dependency triage.

Stacked on #118, so it shows that PR's commit until it lands.

## What it does

```yaml
- name: Run npm audit (production dependencies)
  run: npm audit --omit=dev --audit-level=high     # blocking

- name: Run npm audit
  run: npm audit --audit-level=high                # full tree, visibility
  continue-on-error: true
```

I re-ran both on `develop` rather than taking the numbers from the thread:

```
npm audit --audit-level=high              exit=1     (13 high)
npm audit --omit=dev --audit-level=high   exit=0     found 0 vulnerabilities
```

So the production gate is green today **and** fails for real the day an advisory lands in a shipped path — which is the property the old blanket `continue-on-error` could never have.

Thanks for the `npm audit fix --package-lock-only` measurement. It changes the comment I wrote in #118: keeping the full-tree run non-blocking is not a deferral, it is that **there is no in-range remedy to apply**. The comment in `security.yml` now says that instead.

## This found a bug in #118's guard

Adding the step turned the guard red, and it was right to — but for the wrong reason. The allowlist matched the step name as a **prefix**, so `Run npm audit` also matched `Run npm audit (production dependencies)` declared above it, and it checked the wrong block.

Matching to end-of-line fixes it. Worth flagging plainly: a guard that can be confused by a step whose name *starts with* an allowlisted one is a guard that would eventually pass the wrong thing, and only adding a second audit step surfaced it.

**Verified:** silencing the new blocking step turns the guard red (`27 passed, 1 failed`); restoring it returns to `28 passed`.

## Still open from #109

Item 3 — the `@afixt/a11y-assert@3.1.0` / `afixt-engine ^5.0.0` bump, which wants doing together with the `@afixt/usecase-runner` bump #117 needs. I cannot do that one either: `@afixt/*` are private and I have no `NPM_TOKEN`, so I cannot install or test the upgraded tree. It needs someone with registry access.
