### PR TITLE
chore(deps): Drop the overrides the a11y-assert upgrade made redundant

### DIFF
--- a/package.json
+++ b/package.json
@@ -171,16 +171,5 @@
       "limit": "8kb",
       "gzip": true
     }
-  ],
-  "overrides": {
-    "brace-expansion@1": "^1.1.18",
-    "brace-expansion@2": "^2.1.4",
-    "brace-expansion@5": "^5.0.9",
-    "js-yaml@3": "^3.15.1",
-    "js-yaml@4": "^4.3.1",
-    "js-yaml@5": "^5.2.2",
-    "fast-uri@3": "^3.1.5",
-    "ip-address@10": "^10.3.1",
-    "nanoid@3": "^3.3.18"
-  }
+  ]
 }


### PR DESCRIPTION
Follow-up flagged in #122.

#121 added per-major `overrides` to force six packages past their advisory floors. #122 then upgraded `@afixt/a11y-assert` to 3.0.0, which replaced the whole puppeteer subtree and refreshed those transitive dependencies on its own. The overrides have had nothing to do since.

## Not an argument from reading

Removing them leaves **`package-lock.json` byte-identical**. Every version they targeted resolves exactly the same:

| Package | With overrides | Without |
|---|---|---|
| `brace-expansion` | 1.1.18, 2.1.4, 5.0.9 | **same** |
| `js-yaml` | 3.15.1, 4.3.1, 5.3.0 | **same** |
| `fast-uri` | 3.1.6 | **same** |
| `nanoid` | 3.3.18 | **same** |

`ip-address` was deader still — it left the tree entirely with the puppeteer proxy chain, so that entry was constraining a package that isn't installed.

## Why remove rather than keep as insurance

Because the insurance is now strictly worse than what replaced it. #122 made the full-tree `npm audit` **blocking**, and that gate covers *every* package at *every* severity — these entries covered six by name. Left in place they're hand-maintained config that will happily pin an old major the day one of these packages legitimately moves.

The postcss bump from #121 stays — that's a direct devDependency, not an override.

## Verification

| Check | Result |
|---|---|
| `package-lock.json` | **unchanged** |
| `npm audit` | found 0 vulnerabilities |
| blocking gate / production-only | exit 0 / exit 0 |
| `npm test` | 19 suites / **293 tests** |
| `npm run build` | exit 0 |

Diff is 12 lines out of `package.json` and nothing else.