### PR TITLE
deps: bump @afixt/usecase-runner to ^3.0.0 and guard pointer-independence

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,6 +59,17 @@ jobs:
       - name: Check for code duplication (jscpd)
         run: npm run lint:cpd:ci
 
+      # The unprofiled parse of docs/usecases. `validate:usecases` has existed
+      # in package.json without a caller, so a template could stop parsing and
+      # land green. The companion pointer-independence check is a parse-level
+      # assertion in test/usecases.test.js rather than a job of its own: the
+      # runner's `--profile no-pointer` only enforces at execution time, and
+      # these templates cannot execute here — they carry REPLACE placeholders
+      # instead of a real site's selectors, and their `audit:` steps need
+      # @afixt/afixt-engine, which is deliberately not a dependency.
+      - name: Validate use case templates
+        run: npm run validate:usecases
+
       - name: Upload duplication report
         uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
         if: always()

--- a/README.md
+++ b/README.md
@@ -307,7 +307,13 @@ npm run validate:usecases
 
 That is also asserted by `test/usecases.test.js` during `npm test`, which
 additionally fails on parse _warnings_ — an unknown keyword or modifier
-otherwise parses successfully and then does nothing at runtime.
+otherwise parses successfully and then does nothing at runtime — and on any
+template that uses `hover` or `hover_out`. Those are the two verbs the runner's
+`no-pointer` interaction profile forbids, because a flow that needs a pointer
+cannot be completed by anyone navigating without one. The profile itself
+(`usecase-runner run --profile no-pointer`) only enforces at execution time, so
+the check is made against the parsed steps instead, where it runs on every
+build.
 
 Actually driving a browser needs Playwright (already a dev dependency here) and,
 for the `audit:` steps, the engine:

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "devDependencies": {
         "@afixt/a11y-assert": "^3.0.0",
         "@afixt/a11y-assert-reporter": "^2.0.1",
-        "@afixt/usecase-runner": "^1.5.1",
+        "@afixt/usecase-runner": "^3.0.0",
         "@babel/preset-env": "^7.29.7",
         "@commitlint/cli": "^21.2.1",
         "@commitlint/config-conventional": "^21.2.0",
@@ -967,18 +967,18 @@
       }
     },
     "node_modules/@afixt/usecase-runner": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/@afixt/usecase-runner/-/usecase-runner-1.5.1.tgz",
-      "integrity": "sha512-yhDs26Dq7ywMnyme/bgWgo0Vq0reufwdu6b0dAU7UFst1616yx0qeDnaQpJwN65ssJ56RfmmdI4ASvxVPHlOMA==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@afixt/usecase-runner/-/usecase-runner-3.0.0.tgz",
+      "integrity": "sha512-OZUGmzb4BpSjZO0fAHz7TGOC7bbo974JSjnVx85KVbYotBrAc21uJ3NjAbEHS1qAhh4m1Y/Mp4DCR+WtjeIwog==",
       "dev": true,
       "license": "UNLICENSED",
       "dependencies": {
         "chalk": "^4.1.2",
         "commander": "^12.1.0",
-        "glob": "^11.0.0",
+        "glob": "^13.0.6",
         "handlebars": "^4.7.8",
-        "yaml": "^2.6.1",
-        "zod": "^3.24.1"
+        "yaml": "^2.9.0",
+        "zod": "^4.4.3"
       },
       "bin": {
         "usecase-runner": "bin/usecase-runner.js"
@@ -1015,16 +1015,6 @@
         }
       }
     },
-    "node_modules/@afixt/usecase-runner/node_modules/@isaacs/cliui": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-9.0.0.tgz",
-      "integrity": "sha512-AokJm4tuBHillT+FpMtxQ60n8ObyXBatq7jD2/JA9dxbDDokKQm8KMht5ibGzLVU9IJDIKK4TPKgMHEYMn3lMg==",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
-      "engines": {
-        "node": ">=18"
-      }
-    },
     "node_modules/@afixt/usecase-runner/node_modules/balanced-match": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
@@ -1059,41 +1049,18 @@
       }
     },
     "node_modules/@afixt/usecase-runner/node_modules/glob": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-11.1.0.tgz",
-      "integrity": "sha512-vuNwKSaKiqm7g0THUBu2x7ckSs3XJLXE+2ssL7/MfTGPLLcrJQ/4Uq1CjPTtO5cCIiRxqvN6Twy1qOwhL0Xjcw==",
-      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "version": "13.0.6",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
+      "integrity": "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
-        "foreground-child": "^3.3.1",
-        "jackspeak": "^4.1.1",
-        "minimatch": "^10.1.1",
-        "minipass": "^7.1.2",
-        "package-json-from-dist": "^1.0.0",
-        "path-scurry": "^2.0.0"
-      },
-      "bin": {
-        "glob": "dist/esm/bin.mjs"
+        "minimatch": "^10.2.2",
+        "minipass": "^7.1.3",
+        "path-scurry": "^2.0.2"
       },
       "engines": {
-        "node": "20 || >=22"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/@afixt/usecase-runner/node_modules/jackspeak": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-4.2.3.tgz",
-      "integrity": "sha512-ykkVRwrYvFm1nb2AJfKKYPr0emF6IiXDYUaFx4Zn9ZuIH7MrzEZ3sD5RlqGXNRpHtvUHJyOnCEFxOlNDtGo7wg==",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "@isaacs/cliui": "^9.0.0"
-      },
-      "engines": {
-        "node": "20 || >=22"
+        "node": "18 || 20 || >=22"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
@@ -1140,6 +1107,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@afixt/usecase-runner/node_modules/zod": {
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.5.4.tgz",
+      "integrity": "sha512-sC95tT5iHHH9gtpj6A81kh+NEaRAUFN+qlUPDUbRfOMvNf5QCBqsb3WgvnpVtK5Y+4UfA6KqufotuTvMGiTlsA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     },
     "node_modules/@asamuzakjp/css-color": {

--- a/package.json
+++ b/package.json
@@ -95,7 +95,7 @@
   "devDependencies": {
     "@afixt/a11y-assert": "^3.0.0",
     "@afixt/a11y-assert-reporter": "^2.0.1",
-    "@afixt/usecase-runner": "^1.5.1",
+    "@afixt/usecase-runner": "^3.0.0",
     "@babel/preset-env": "^7.29.7",
     "@commitlint/cli": "^21.2.1",
     "@commitlint/config-conventional": "^21.2.0",

--- a/test/usecases.test.js
+++ b/test/usecases.test.js
@@ -53,6 +53,25 @@ const VERBS_ADDED_IN_1_4_0 = ['contrast', 'lang_check', 'read_image', 'sr_says']
 const MIN_RUNNER = [1, 4, 0];
 
 /**
+ * The verbs `@afixt/usecase-runner`'s `no-pointer` interaction profile forbids
+ * (`run --profile no-pointer`, added in 1.7.0). A tooltip that only appears on
+ * hover, or a carousel that advances on pointer-over, cannot be operated by
+ * anyone navigating without a pointing device — but a test that hovers passes
+ * happily, because Playwright can hover when a real user cannot.
+ *
+ * The profile enforces this when a use case *executes*: `run` fails the step
+ * with `failure_reason: 'profile_forbidden'`, and `generate --profile
+ * no-pointer` compiles it into a `throw`. Neither is reachable from this
+ * repository's CI — these are templates, so their `data:` blocks carry REPLACE
+ * placeholders rather than a real site's selectors, and every one of them has
+ * an `audit:` step, which needs `@afixt/afixt-engine` (not a dependency here).
+ * The property itself is static, though: whether a flow needs a pointer is a
+ * fact about its steps, not about the page. So it is asserted here, where it
+ * runs on every `npm test`.
+ */
+const POINTER_ONLY_KEYWORDS = ['hover', 'hover_out'];
+
+/**
  * Lowest version a semver range can resolve to. `^1.5.1`, `~1.5.1` and
  * `>=1.5.1` all floor at 1.5.1; anything without three numeric parts (`*`,
  * `latest`, a git URL) yields null and is treated as unpinnable.
@@ -113,6 +132,23 @@ describe('docs/usecases templates', () => {
     for (const verb of atRisk) {
       expect(STEP_KEYWORDS).toContain(verb);
     }
+  });
+
+  it('keeps every flow completable without a pointer', () => {
+    // Guard the guard, the same way the keyword test above does: if the runner
+    // ever renames or drops these verbs, the filter below matches nothing and
+    // this test passes while watching nothing.
+    for (const keyword of POINTER_ONLY_KEYWORDS) {
+      expect(STEP_KEYWORDS).toContain(keyword);
+    }
+
+    const pointerOnly = useCases.flatMap(useCase =>
+      useCase.steps
+        .filter(step => POINTER_ONLY_KEYWORDS.includes(step.keyword))
+        .map(step => `${useCase.id}: ${step.keyword}`)
+    );
+
+    expect(pointerOnly).toEqual([]);
   });
 
   it('pins @afixt/usecase-runner at or above the version that added those verbs', () => {


### PR DESCRIPTION
## What

Bumps `@afixt/usecase-runner` from `^1.5.1` to `^3.0.0`, adds a parse-level guard that no use case template depends on a pointer, and wires the previously-uncalled `npm run validate:usecases` into the `check` job.

Closes #117.

## The issue is stale, and the correction matters

#117 was filed against **1.7.0** and says the jump from `^1.5.1` is "all semver-minor, no breaking changes". npm `latest` is now **3.0.0**. The real move crosses two majors.

| Released | On npm | |
| --- | --- | --- |
| 1.6.0, 1.6.1 | no | tagged, never published — as #117 noted |
| 1.7.0 | yes | interaction profiles |
| 2.0.0, 2.0.1 | yes | **breaking**: parser rejects input 1.7.0 accepted |
| 2.0.2, 2.0.3 | **no** | GitHub-released, never published |
| 2.1.0 | yes | `force` modifier |
| 3.0.0 | yes | **breaking**: modifier and `via` strictness |

Both majors are the same class of change: a step that read as expressing one behaviour and quietly executed another is now a parse error.

**It is safe here, and that is measured rather than assumed:**

- All eight templates in `docs/usecases` validate clean under 3.0.0. The rejections target `keyboard:` carrying literal text, non-literal boolean modifiers, `via` values other than `keyboard`, and modifiers on keywords that never declared them. This repo's three `keyboard:` steps name keys (`Tab`, `Escape`), all eleven `via` clauses say `keyboard`, and no step carries a boolean modifier.
- `test/usecases.test.js` consumes the package's API directly — `parseUseCaseDirectory`, `getParseWarnings`, `STEP_KEYWORDS`. All fourteen existing assertions pass against 3.0.0, including the one that fails on parse *warnings*.
- Upstream's known gap for 3.0.0 (`wait`, `wait_for`, `scroll`, `lang_check` still drop trailing input) cannot bite here: every such step in these templates is a bare target with nothing trailing. A future fix tightening those is therefore also safe.
- `--profile no-pointer` still exists in 3.0.0 in exactly the shape #117 describes.

## Why the profiled check is not a second CI job

#117 suggests a profiled run "as a second job alongside the existing unprofiled run". Two things turned out not to hold.

**There was no existing unprofiled run.** `validate:usecases` has been in `package.json` since the templates landed, with nothing in `.github/workflows` calling it and no place in `check:all`. This PR wires it into the `check` job.

**The profile enforces at execution time, and these templates cannot execute in CI.** Measured, not inferred:

- `generate --profile no-pointer` exits 0 and compiles the step into `throw new Error('Step uses "hover", which the "no-pointer" interaction profile forbids…')`. It is not a static gate.
- `run --profile no-pointer` is the real gate — but the templates are templates. Their `data:` blocks carry REPLACE placeholders rather than a real site's selectors, and every one has an `audit:` step, which needs `@afixt/afixt-engine`, deliberately not a dependency here.

A real run confirms it. Running `reject-all` against this repo's own served demo page, with and without the profile:

- Identical step for step: 13 fail, 1 passes, in both.
- Failures are `locator.waitFor: Timeout 30000ms exceeded` on `getByRole('region', { name: 'Cookie Consent' })`, and `audit steps require @afixt/afixt-engine to be installed`.
- **Zero `profile_forbidden`.** The report does record `profile: "no-pointer"`, so the flag works — there is simply nothing for it to forbid.
- ~180s for one of eight use cases.

A profiled CI job would therefore be permanently red for reasons that have nothing to do with hover, which is the opposite of the signal #117 wants.

## What replaces it

Whether a flow needs a pointer is a fact about its steps, not about the page. So the check is made over the parsed steps, in `test/usecases.test.js`, alongside the guards already there — running on every `npm test`, which the `check` job already invokes.

It is confirmed to **fail**, not merely to pass: injecting a `hover:` step into `reject-all.uc.yaml` turns it red and names the template and the verb.

```
✕ keeps every flow completable without a pointer
  - Array []
  + Array [ "cookie-banner-reject-all: hover" ]
```

It also guards the guard, in the idiom the neighbouring keyword test uses: if the runner ever renames or drops `hover`/`hover_out`, the filter would match nothing and pass while watching nothing, so the test asserts both verbs are still in `STEP_KEYWORDS`.

Current result: **no template in this repo depends on hover** — which is the answer #117 was asking for.

## Verification

Run locally against this branch:

| Gate | Result |
| --- | --- |
| `npm run lint` | pass |
| `npm run format:check` | pass |
| `npm run lint:css` | pass |
| `npm run lint:md` | pass |
| `npm run lint:cpd:ci` | pass |
| `npm run lint:licenses` | pass |
| `npm run validate:usecases` | pass — 8 use cases, under 3.0.0 |
| `npm run build` | pass |
| `npm test` | pass — 19 suites, 294 tests |

Lockfile churn is small: `@afixt/usecase-runner`'s nested `@isaacs/cliui` and `jackspeak` drop out, `zod` comes in.

## Not done here

The full browser run of these templates remains a manual activity, as the README already describes. Making it a CI job would need `@afixt/afixt-engine` and `@afixt/test-utils` as dev dependencies and a fixture page whose selectors match the templates' `data:` blocks — a larger change than #117 contemplates, and worth its own issue if it is wanted.
