### PR TITLE
test(coverage): Raise the global thresholds to what the suite covers

### DIFF
--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -35,11 +35,15 @@ module.exports = {
   collectCoverage: true,
   collectCoverageFrom: ['src/js/**/*.js', '!**/node_modules/**', '!**/dist/**', '!**/coverage/**'],
   coverageThreshold: {
+    // Floors at the coverage measured when #128 was fixed, so the gate fails on
+    // any regression. The old values (14/14/20/25) sat 60+ points below what the
+    // suite actually covers and could not catch anything. Raise these as
+    // coverage grows; never lower them to make a change pass.
     global: {
-      branches: 25,
-      functions: 20,
-      lines: 14,
-      statements: 14,
+      branches: 74,
+      functions: 87,
+      lines: 86,
+      statements: 85,
     },
   },
 };


### PR DESCRIPTION
Closes #128. Resolves the question in #127 too; see below.

## #128: thresholds that could not fail

| Metric | Old threshold | Measured now | New threshold |
| --- | --- | --- | --- |
| statements | 14 | 85.92 | **85** |
| lines | 14 | 86.03 | **86** |
| functions | 20 | 87.59 | **87** |
| branches | 25 | 74.3 | **74** |

Each new value is the integer floor of today's measurement, so the gate fails on any regression and never on today's tree. A comment in `jest.config.cjs` says to raise them as coverage grows and never lower them to get a change through.

**Probed.** With `test/banner.test.js` removed, which drops coverage the way a deleted or skipped suite would:

| | jest exit |
| --- | --- |
| old thresholds | **0**: the regression goes through |
| new thresholds | **1** |
| new thresholds, full suite | **0** |

## #127's premise doesn't hold

#127 says a `coverageThreshold` is set but nothing executes it. It is executed: `jest.config.cjs` sets **`collectCoverage: true`**, so plain `npm test` evaluates the threshold. `check:all`, which pre-push runs, calls `npm test`, and CI runs `test:coverage`. The audit looked for `test:coverage` inside the gate script and missed that the config turns coverage on for every run. The real problem was the one #128 names, the values, and this PR fixes that. I'll close #127 with this evidence once this merges.

Built in an isolated worktree off `develop`, on Node 22 (the repo's `.nvmrc`). The push ran the real pre-push hook (`check:all`). Your checkout wasn't touched.